### PR TITLE
Improved JPA support

### DIFF
--- a/persistence-support/jdbc/pom.xml
+++ b/persistence-support/jdbc/pom.xml
@@ -69,7 +69,6 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.2.9</version>
             <scope>test</scope>
         </dependency>
 	</dependencies>

--- a/persistence-support/jdbc/src/it/java/org/seedstack/seed/persistence/jdbc/JdbcPersistenceIT.java
+++ b/persistence-support/jdbc/src/it/java/org/seedstack/seed/persistence/jdbc/JdbcPersistenceIT.java
@@ -32,10 +32,17 @@ public class JdbcPersistenceIT {
     @Inject
     private Repository repository;
 
+    private static boolean alreadyInited;
+
     @Transactional
     @Jdbc
     @Before
     public void init() throws SQLException {
+        if (alreadyInited) {
+            repository.drop();
+        } else {
+            alreadyInited = true;
+        }
         repository.init();
     }
 

--- a/persistence-support/jdbc/src/it/java/org/seedstack/seed/persistence/jdbc/sample/Repository.java
+++ b/persistence-support/jdbc/src/it/java/org/seedstack/seed/persistence/jdbc/sample/Repository.java
@@ -31,22 +31,13 @@ public class Repository {
     @Inject
     private Connection connection;
 
-    public void init() throws SQLException {
-        try {
-            drop();
-        } catch (SQLException e) {
-            // Table already exists
-        }
-        createTable();
-    }
-
     public void drop() throws SQLException {
         Statement stmnt = connection.createStatement();
         String sql = "DROP TABLE FOO";
         stmnt.executeUpdate(sql);
     }
 
-    public void createTable() throws SQLException {
+    public void init() throws SQLException {
         Statement stmnt = connection.createStatement();
         String sql = "CREATE TABLE FOO (id INTEGER not NULL, bar varchar(255), PRIMARY KEY (id))";
         stmnt.executeUpdate(sql);

--- a/persistence-support/jdbc/src/main/java/org/seedstack/seed/persistence/jdbc/internal/JdbcConnectionLink.java
+++ b/persistence-support/jdbc/src/main/java/org/seedstack/seed/persistence/jdbc/internal/JdbcConnectionLink.java
@@ -33,13 +33,13 @@ public class JdbcConnectionLink implements TransactionalLink<Connection> {
 
     @Override
     public Connection get() {
-        Connection connection = this.perThreadObjectContainer.get().peek().getConnection();
+        JdbcTransaction transaction = this.perThreadObjectContainer.get().peek();
 
-        if (connection == null) {
+        if (transaction == null) {
             throw SeedException.createNew(JdbcErrorCode.ACCESSING_JDBC_CONNECTION_OUTSIDE_TRANSACTION);
         }
 
-        return connection;
+        return transaction.getConnection();
     }
 
     Connection getCurrentConnection() {

--- a/persistence-support/jpa/pom.xml
+++ b/persistence-support/jpa/pom.xml
@@ -28,6 +28,11 @@
         </dependency>
         <dependency>
             <groupId>org.seedstack.seed</groupId>
+            <artifactId>seed-persistence-support-jdbc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seedstack.seed</groupId>
             <artifactId>seed-transaction-support</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -62,7 +67,6 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.2.9</version>
             <scope>test</scope>
         </dependency>
 	</dependencies>

--- a/persistence-support/jpa/src/it/java/org/seedstack/seed/persistence/jpa/NoPersistenceXmlIT.java
+++ b/persistence-support/jpa/src/it/java/org/seedstack/seed/persistence/jpa/NoPersistenceXmlIT.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+/*
+ * Creation : 18 mars 2015
+ */
+package org.seedstack.seed.persistence.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.seedstack.seed.it.SeedITRunner;
+import org.seedstack.seed.persistence.jpa.api.JpaUnit;
+import org.seedstack.seed.persistence.jpa.sample2.Item;
+import org.seedstack.seed.persistence.jpa.sample2.ItemRepository;
+import org.seedstack.seed.persistence.jpa.sample2.OtherItem;
+import org.seedstack.seed.transaction.api.Transactional;
+
+@Transactional
+@JpaUnit("unit4")
+@RunWith(SeedITRunner.class)
+public class NoPersistenceXmlIT {
+
+    @Inject
+    private ItemRepository itemRepository;
+
+    @Test
+    public void testRepository() {
+        Item item = new Item();
+        item.setName("itemName");
+        itemRepository.save(item);
+        assertThat(item.getID()).isEqualTo(1L);
+    }
+
+    @Test
+    public void testOtherItem() {
+        OtherItem item = new OtherItem();
+        item.setName("name");
+        itemRepository.save(item);
+    }
+
+}

--- a/persistence-support/jpa/src/it/java/org/seedstack/seed/persistence/jpa/sample2/Item.java
+++ b/persistence-support/jpa/src/it/java/org/seedstack/seed/persistence/jpa/sample2/Item.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.persistence.jpa.sample2;
+
+import java.io.Serializable;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@SuppressWarnings("serial")
+@Entity
+public class Item implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private long ID;
+
+    private String name = "";
+
+    public long getID() {
+        return ID;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (int) (ID ^ (ID >>> 32));
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Item other = (Item) obj;
+        return name.equals(other.name) && ID == other.ID;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Item [ID=%s, name=%s]", ID, name);
+    }
+
+}

--- a/persistence-support/jpa/src/it/java/org/seedstack/seed/persistence/jpa/sample2/ItemRepository.java
+++ b/persistence-support/jpa/src/it/java/org/seedstack/seed/persistence/jpa/sample2/ItemRepository.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.persistence.jpa.sample2;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import org.seedstack.seed.it.api.ITBind;
+
+@ITBind
+public class ItemRepository {
+    private EntityManager entityManager;
+
+    @Inject
+    public ItemRepository(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    public void save(Item item) {
+        entityManager.persist(item);
+    }
+
+    public void save(OtherItem item) {
+        entityManager.persist(item);
+    }
+}

--- a/persistence-support/jpa/src/it/java/org/seedstack/seed/persistence/jpa/sample2/OtherItem.java
+++ b/persistence-support/jpa/src/it/java/org/seedstack/seed/persistence/jpa/sample2/OtherItem.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+/*
+ * Creation : 18 mars 2015
+ */
+package org.seedstack.seed.persistence.jpa.sample2;
+
+public class OtherItem {
+
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/persistence-support/jpa/src/it/resources/META-INF/configuration/org.seedstack.seed.persistence.jpa.props
+++ b/persistence-support/jpa/src/it/resources/META-INF/configuration/org.seedstack.seed.persistence.jpa.props
@@ -9,7 +9,11 @@
 #
 
 [org.seedstack.seed]
-persistence.jpa.units=unit1, unit2, unit3
+persistence.jpa.units=unit1, unit2, unit3, unit4
+
+[org.seedstack.seed.persistence.jdbc]
+datasources=datasource1
+
 
 [org.seedstack.seed.persistence.jpa.unit.unit1]
 property.javax.persistence.jdbc.driver=org.hsqldb.jdbcDriver
@@ -39,3 +43,21 @@ property.hibernate.dialect=org.hibernate.dialect.HSQLDialect
 property.hibernate.hbm2ddl.auto=create
 property.sql.enforce_strict_size=true
 
+[org.seedstack.seed.persistence.jpa.unit.unit4]
+datasource=datasource1
+#jta-datasource=datasource1
+mapping-file = META-INF/otherItem.xml
+property.hibernate.dialect=org.hibernate.dialect.HSQLDialect
+property.hibernate.hbm2ddl.auto=create
+
+[org.seedstack.seed.persistence.jdbc.datasource.datasource1]
+#context=someContext
+#jndi-name=java:/myAppDS
+driver=org.hsqldb.jdbcDriver
+url=jdbc:hsqldb:mem:testdb4
+user=sa
+password=
+property.sql.enforce_strict_size=true
+
+[org.seedstack.seed.persistence.jpa.sample2.*]
+jpa-unit = unit4

--- a/persistence-support/jpa/src/it/resources/META-INF/otherItem.xml
+++ b/persistence-support/jpa/src/it/resources/META-INF/otherItem.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+
+    This file is part of SeedStack, An enterprise-oriented full development stack.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<entity-mappings xmlns="http://java.sun.com/xml/ns/persistence/orm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence/orm ;  
+http://java.sun.com/xml/ns/persistence/orm_1_0.xsd" version="1.0">
+    <description>My First JPA XML Application</description>
+    <package>org.seedstack.seed.persistence.jpa.sample2</package>
+    <entity class="OtherItem" name="OtherItem">
+        <table name="OTHERITEM" />
+        <attributes>
+            <id name="name"/>
+        </attributes>
+    </entity>
+</entity-mappings>

--- a/persistence-support/jpa/src/main/java/org/seedstack/seed/persistence/jpa/internal/InternalPersistenceUnitInfo.java
+++ b/persistence-support/jpa/src/main/java/org/seedstack/seed/persistence/jpa/internal/InternalPersistenceUnitInfo.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+/*
+ * Creation : 12 mars 2015
+ */
+package org.seedstack.seed.persistence.jpa.internal;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import javax.persistence.SharedCacheMode;
+import javax.persistence.ValidationMode;
+import javax.persistence.spi.ClassTransformer;
+import javax.persistence.spi.PersistenceUnitInfo;
+import javax.persistence.spi.PersistenceUnitTransactionType;
+import javax.sql.DataSource;
+
+class InternalPersistenceUnitInfo implements PersistenceUnitInfo {
+
+    String persistenceUnitName;
+
+    String persistenceProviderClassName;
+
+    PersistenceUnitTransactionType persistenceUnitTransactionType = PersistenceUnitTransactionType.RESOURCE_LOCAL;
+
+    DataSource jtaDataSource;
+
+    DataSource nonJtaDataSource;
+
+    List<String> mappingFileNames;
+
+    List<String> managedClassNames;
+
+    SharedCacheMode sharedCacheMode = SharedCacheMode.UNSPECIFIED;
+
+    ValidationMode validationMode = ValidationMode.AUTO;
+
+    Properties properties;
+
+    @Override
+    public String getPersistenceUnitName() {
+        return persistenceUnitName;
+    }
+
+    @Override
+    public String getPersistenceProviderClassName() {
+        return persistenceProviderClassName;
+    }
+
+    @Override
+    public PersistenceUnitTransactionType getTransactionType() {
+        return persistenceUnitTransactionType;
+    }
+
+    @Override
+    public DataSource getJtaDataSource() {
+        return jtaDataSource;
+    }
+
+    @Override
+    public DataSource getNonJtaDataSource() {
+        return nonJtaDataSource;
+    }
+
+    @Override
+    public List<String> getMappingFileNames() {
+        return mappingFileNames;
+    }
+
+    @Override
+    public List<URL> getJarFileUrls() {
+        // Not used as Seed will scan the classes
+        return Collections.emptyList();
+    }
+
+    @Override
+    public URL getPersistenceUnitRootUrl() {
+        // Not used as Seed will scan the classes
+        return null;
+    }
+
+    @Override
+    public List<String> getManagedClassNames() {
+        return managedClassNames;
+    }
+
+    @Override
+    public boolean excludeUnlistedClasses() {
+        // Not used as Seed will scan the classes
+        return false;
+    }
+
+    @Override
+    public SharedCacheMode getSharedCacheMode() {
+        return sharedCacheMode;
+    }
+
+    @Override
+    public ValidationMode getValidationMode() {
+        return validationMode;
+    }
+
+    @Override
+    public Properties getProperties() {
+        return properties;
+    }
+
+    @Override
+    public String getPersistenceXMLSchemaVersion() {
+        return null;
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        // not supported
+        return null;
+    }
+
+    @Override
+    public void addTransformer(ClassTransformer transformer) {
+        // does nothing
+    }
+
+    @Override
+    public ClassLoader getNewTempClassLoader() {
+        // not supported
+        return null;
+    }
+
+}

--- a/persistence-support/jpa/src/main/java/org/seedstack/seed/persistence/jpa/internal/JpaPlugin.java
+++ b/persistence-support/jpa/src/main/java/org/seedstack/seed/persistence/jpa/internal/JpaPlugin.java
@@ -13,26 +13,34 @@ import io.nuun.kernel.api.Plugin;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.PluginException;
 import io.nuun.kernel.api.plugin.context.InitContext;
+import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
+import io.nuun.kernel.api.plugin.request.ClasspathScanRequestBuilder;
 import io.nuun.kernel.core.AbstractPlugin;
-import org.apache.commons.configuration.Configuration;
-import org.seedstack.seed.core.internal.application.ApplicationPlugin;
-import org.seedstack.seed.persistence.jpa.api.JpaExceptionHandler;
-import org.seedstack.seed.transaction.internal.TransactionPlugin;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import javax.persistence.Embeddable;
+import javax.persistence.Entity;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import javax.persistence.PersistenceException;
+
+import org.apache.commons.configuration.Configuration;
+import org.seedstack.seed.core.api.Application;
+import org.seedstack.seed.core.internal.application.ApplicationPlugin;
+import org.seedstack.seed.persistence.jdbc.internal.JdbcPlugin;
+import org.seedstack.seed.persistence.jpa.api.JpaExceptionHandler;
+import org.seedstack.seed.transaction.internal.TransactionPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
- * This plugin enables JPA support by creating an {@link javax.persistence.EntityManagerFactory} per persistence
- * unit configured.
- *
+ * This plugin enables JPA support by creating an {@link javax.persistence.EntityManagerFactory} per persistence unit configured.
+ * 
  * @author adrien.lauer@mpsa.com
  */
 public class JpaPlugin extends AbstractPlugin {
@@ -53,11 +61,16 @@ public class JpaPlugin extends AbstractPlugin {
     public InitState init(InitContext initContext) {
         Configuration jpaConfiguration = null;
         TransactionPlugin transactionPlugin = null;
+        JdbcPlugin jdbcPlugin = null;
+        Application application = null;
         for (Plugin plugin : initContext.pluginsRequired()) {
             if (plugin instanceof ApplicationPlugin) {
-                jpaConfiguration = ((ApplicationPlugin) plugin).getApplication().getConfiguration().subset(JpaPlugin.JPA_PLUGIN_CONFIGURATION_PREFIX);
+                application = ((ApplicationPlugin) plugin).getApplication();
+                jpaConfiguration = application.getConfiguration().subset(JpaPlugin.JPA_PLUGIN_CONFIGURATION_PREFIX);
             } else if (plugin instanceof TransactionPlugin) {
-                transactionPlugin = ((TransactionPlugin) plugin);
+                transactionPlugin = (TransactionPlugin) plugin;
+            } else if (plugin instanceof JdbcPlugin) {
+                jdbcPlugin = (JdbcPlugin) plugin;
             }
         }
 
@@ -68,39 +81,53 @@ public class JpaPlugin extends AbstractPlugin {
             throw new PluginException("Unable to find transaction plugin");
         }
 
-        String[] persistenceUnits = jpaConfiguration.getStringArray("units");
-        if (persistenceUnits != null && persistenceUnits.length > 0) {
-            for (String persistenceUnit : persistenceUnits) {
-                Configuration persistenceUnitConfiguration = jpaConfiguration.subset("unit." + persistenceUnit);
-
-                Iterator<String> it = persistenceUnitConfiguration.getKeys("property");
-                Map<String, String> properties = new HashMap<String, String>();
-                while (it.hasNext()) {
-                    String name = it.next();
-                    properties.put(name.substring(9), persistenceUnitConfiguration.getString(name));
-                }
-
-                LOGGER.info("Creating entity manager factory for persistence unit " + persistenceUnit);
-                entityManagerFactories.put(persistenceUnit, Persistence.createEntityManagerFactory(persistenceUnit, properties));
-
-                String exceptionHandler = persistenceUnitConfiguration.getString("exception-handler");
-                if (exceptionHandler != null && !exceptionHandler.isEmpty()) {
-                    try {
-                        exceptionHandlerClasses.put(persistenceUnit, (Class<? extends JpaExceptionHandler>) Class.forName(exceptionHandler));
-                    } catch (Exception e) {
-                        throw new PluginException("Unable to load class " + exceptionHandler, e);
-                    }
-                }
-            }
-
-            if (persistenceUnits.length == 1) {
-                JpaTransactionMetadataResolver.defaultJpaUnit = persistenceUnits[0];
-            }
-
-            transactionPlugin.registerTransactionHandler(JpaTransactionHandler.class);
-        } else {
-        	LOGGER.info("No JPA persistence unit configured, JPA support disabled");
+        String[] persistenceUnitNames = jpaConfiguration.getStringArray("units");
+        if (persistenceUnitNames != null && persistenceUnitNames.length == 0) {
+            LOGGER.info("No JPA persistence unit configured, JPA support disabled");
+            return InitState.INITIALIZED;
         }
+        for (String persistenceUnit : persistenceUnitNames) {
+            Configuration persistenceUnitConfiguration = jpaConfiguration.subset("unit." + persistenceUnit);
+            Iterator<String> it = persistenceUnitConfiguration.getKeys("property");
+            Map<String, String> properties = new HashMap<String, String>();
+            while (it.hasNext()) {
+                String name = it.next();
+                properties.put(name.substring(9), persistenceUnitConfiguration.getString(name));
+            }
+
+            SeedConfEntityManagerFactoryResolver confResolver = new SeedConfEntityManagerFactoryResolver();
+            EntityManagerFactory emf = null;
+            try {
+                emf = Persistence.createEntityManagerFactory(persistenceUnit, properties);
+            } catch (PersistenceException e) {
+                Collection<Class<?>> scannedClasses = new ArrayList<Class<?>>();
+                if (initContext.scannedClassesByAnnotationClass().get(Entity.class) != null) {
+                    scannedClasses.addAll(initContext.scannedClassesByAnnotationClass().get(Entity.class));
+                }
+                if (initContext.scannedClassesByAnnotationClass().get(Embeddable.class) != null) {
+                    scannedClasses.addAll(initContext.scannedClassesByAnnotationClass().get(Embeddable.class));
+                }
+                try {
+                    emf = confResolver.resolve(persistenceUnit, properties, persistenceUnitConfiguration, application, jdbcPlugin, scannedClasses);
+                } catch (UnitNotConfiguredException noConfEx) {
+                    throw e;
+                }
+            }
+            entityManagerFactories.put(persistenceUnit, emf);
+            String exceptionHandler = persistenceUnitConfiguration.getString("exception-handler");
+            if (exceptionHandler != null && !exceptionHandler.isEmpty()) {
+                try {
+                    exceptionHandlerClasses.put(persistenceUnit, (Class<? extends JpaExceptionHandler>) Class.forName(exceptionHandler));
+                } catch (Exception e) {
+                    throw new PluginException("Unable to load class " + exceptionHandler, e);
+                }
+            }
+        }
+        if (persistenceUnitNames.length == 1) {
+            JpaTransactionMetadataResolver.defaultJpaUnit = persistenceUnitNames[0];
+        }
+
+        transactionPlugin.registerTransactionHandler(JpaTransactionHandler.class);
 
         return InitState.INITIALIZED;
     }
@@ -118,6 +145,7 @@ public class JpaPlugin extends AbstractPlugin {
         Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
         plugins.add(ApplicationPlugin.class);
         plugins.add(TransactionPlugin.class);
+        plugins.add(JdbcPlugin.class);
         return plugins;
     }
 
@@ -125,4 +153,10 @@ public class JpaPlugin extends AbstractPlugin {
     public Object nativeUnitModule() {
         return new JpaModule(entityManagerFactories, exceptionHandlerClasses);
     }
+
+    @Override
+    public Collection<ClasspathScanRequest> classpathScanRequests() {
+        return new ClasspathScanRequestBuilder().annotationType(Entity.class).annotationType(Embeddable.class).build();
+    }
+
 }

--- a/persistence-support/jpa/src/main/java/org/seedstack/seed/persistence/jpa/internal/SeedConfEntityManagerFactoryResolver.java
+++ b/persistence-support/jpa/src/main/java/org/seedstack/seed/persistence/jpa/internal/SeedConfEntityManagerFactoryResolver.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+/*
+ * Creation : 19 mars 2015
+ */
+package org.seedstack.seed.persistence.jpa.internal;
+
+import io.nuun.kernel.api.plugin.PluginException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceException;
+import javax.persistence.SharedCacheMode;
+import javax.persistence.ValidationMode;
+import javax.persistence.spi.PersistenceProvider;
+import javax.persistence.spi.PersistenceProviderResolverHolder;
+import javax.persistence.spi.PersistenceUnitTransactionType;
+import javax.sql.DataSource;
+
+import org.apache.commons.configuration.Configuration;
+import org.seedstack.seed.core.api.Application;
+import org.seedstack.seed.persistence.jdbc.internal.JdbcPlugin;
+
+class SeedConfEntityManagerFactoryResolver {
+
+    Map<String, EntityManagerFactory> entityManagerFactories = new HashMap<String, EntityManagerFactory>();
+
+    Map<String, Exception> unitsInException = new HashMap<String, Exception>();
+
+    EntityManagerFactory resolve(String persistenceUnit, Map<String, String> properties, Configuration unitConfiguration, Application application,
+            JdbcPlugin jdbcPlugin, Collection<Class<?>> scannedClasses) throws UnitNotConfiguredException {
+        String dataSourceName = unitConfiguration.getString("datasource");
+        String jtaDataSourceName = unitConfiguration.getString("jta-datasource");
+        if (dataSourceName == null && jtaDataSourceName == null) {
+            throw new UnitNotConfiguredException("No property datasource or jta-datasource found for persistenceUnit [" + persistenceUnit
+                    + "]. One of these properties is required to load the persistence unit from seed configuration");
+        }
+        DataSource dataSource;
+        boolean isJta = false;
+        if (jtaDataSourceName != null) {
+            dataSource = jdbcPlugin.getDataSources().get(jtaDataSourceName);
+            isJta = true;
+        } else {
+            dataSource = jdbcPlugin.getDataSources().get(dataSourceName);
+        }
+
+        InternalPersistenceUnitInfo unitInfo = new InternalPersistenceUnitInfo();
+        unitInfo.persistenceUnitName = persistenceUnit;
+        if (isJta)
+            unitInfo.jtaDataSource = dataSource;
+        else
+            unitInfo.nonJtaDataSource = dataSource;
+
+        unitInfo.managedClassNames = new ArrayList<String>();
+        for (Class<?> managed : scannedClasses) {
+            if (persistenceUnit.equals(application.getConfiguration(managed).getString("jpa-unit"))) {
+                unitInfo.managedClassNames.add(managed.getName());
+            }
+        }
+        if (unitInfo.managedClassNames.isEmpty()) {
+            throw new PluginException("No class was configured to belong to jpa unit [" + persistenceUnit + "]");
+        }
+        if (unitConfiguration.getString("mapping-file") != null) {
+            unitInfo.mappingFileNames = Arrays.asList(unitConfiguration.getString("mapping-file"));
+        } else {
+            unitInfo.mappingFileNames = Collections.emptyList();
+        }
+        unitInfo.properties = new Properties();
+        unitInfo.properties.putAll(properties);
+        if (unitConfiguration.getString("validation-mode") != null)
+            unitInfo.validationMode = ValidationMode.valueOf(unitConfiguration.getString("validation-mode"));
+        if (unitConfiguration.getString("shared-cache-mode") != null)
+            unitInfo.sharedCacheMode = SharedCacheMode.valueOf(unitConfiguration.getString("shared-cache-mode"));
+        if (unitConfiguration.getString("transaction-type") != null)
+            unitInfo.persistenceUnitTransactionType = PersistenceUnitTransactionType.valueOf(unitConfiguration.getString("transaction-type"));
+
+        return createEntityManagerFactory(unitInfo, properties);
+    }
+
+    // Method inspired by javax.persistence.Persistence.createEntityManagerFactory(String, Map)
+    private EntityManagerFactory createEntityManagerFactory(InternalPersistenceUnitInfo info, Map<String, String> map) {
+        EntityManagerFactory fac = null;
+        List<PersistenceProvider> persistenceProviders = PersistenceProviderResolverHolder.getPersistenceProviderResolver().getPersistenceProviders();
+        for (PersistenceProvider persistenceProvider : persistenceProviders) {
+            info.persistenceProviderClassName = persistenceProvider.getClass().getName();
+            fac = persistenceProvider.createContainerEntityManagerFactory(info, map);
+            if (fac != null) {
+                break;
+            }
+        }
+        if (fac == null) {
+            throw new PersistenceException("No Persistence provider for EntityManager named " + info.getPersistenceUnitName());
+        }
+        return fac;
+    }
+}

--- a/persistence-support/jpa/src/main/java/org/seedstack/seed/persistence/jpa/internal/UnitNotConfiguredException.java
+++ b/persistence-support/jpa/src/main/java/org/seedstack/seed/persistence/jpa/internal/UnitNotConfiguredException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+/*
+ * Creation : 19 mars 2015
+ */
+package org.seedstack.seed.persistence.jpa.internal;
+
+class UnitNotConfiguredException extends Exception {
+
+    private static final long serialVersionUID = 6525564562654268478L;
+
+    UnitNotConfiguredException() {
+        super();
+    }
+
+    UnitNotConfiguredException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    UnitNotConfiguredException(String message) {
+        super(message);
+    }
+
+    UnitNotConfiguredException(Throwable cause) {
+        super(cause);
+    }
+
+}


### PR DESCRIPTION
This pull request concerns a few enhancements on jpa support following the introduction of the jdbc support.
* A jpa unit can be fully configured in the props (persistence.xml not necessary)
* A datasource defined with jdbc-support can be used for the unit
* Possibility to attach a package to a jpa unit (entities are scanned)
* Possibility to define the mapping of the entities of a unit by using a orm.xml type file

Closes #9 
Closes #16 