### PR TITLE
Add a declarative way to register a JMS ExceptionListener using props

### DIFF
--- a/jms-support/core/src/it/java/org/seedstack/seed/jms/internal/ManagedReconnectionFeatureIT.java
+++ b/jms-support/core/src/it/java/org/seedstack/seed/jms/internal/ManagedReconnectionFeatureIT.java
@@ -60,6 +60,10 @@ public class ManagedReconnectionFeatureIT {
     @Inject
     @Named("connection5")
     private Connection connection5;
+    
+    @Inject
+    @Named("connection6")
+    private Connection connection6;
 
     @Test
     public void reset_then_refresh_connection_should_works() throws Exception {
@@ -178,6 +182,18 @@ public class ManagedReconnectionFeatureIT {
         ExceptionListener exceptionListenerMC = Whitebox.getInternalState(managedConnection, "exceptionListener");
         Assertions.assertThat(exceptionListenerAQ).isNotEqualTo(exceptionListenerMC);
         Assertions.assertThat(exceptionListenerMC).isEqualTo(exceptionListener);       
+        
+    }
+    
+    @Test
+    public void test_that_wraped_exceptionlistener_from_managedConnection_is_declared_using_props() throws InterruptedException, JMSException {
+        ManagedConnection managedConnection = ((ManagedConnection)connection6);
+        managedConnection.onException(new JMSException("test"));
+        ExceptionListener exceptionListenerMC = Whitebox.getInternalState(managedConnection, "exceptionListener");
+        Assertions.assertThat(exceptionListenerMC).isInstanceOf(MyExceptionListener.class);
+        Logger logger = Whitebox.getInternalState(exceptionListenerMC, "LOGGER");
+        Assertions.assertThat(logger).isNotNull();
+
         
     }
 

--- a/jms-support/core/src/it/java/org/seedstack/seed/jms/internal/MyExceptionListener.java
+++ b/jms-support/core/src/it/java/org/seedstack/seed/jms/internal/MyExceptionListener.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.jms.internal;
+
+import javax.jms.ExceptionListener;
+import javax.jms.JMSException;
+
+import org.seedstack.seed.core.api.Logging;
+import org.slf4j.Logger;
+
+/**
+ * Dummy exceptionListener for tests
+ * @author redouane.loulou@ext.mpsa.com
+ *
+ */
+public class MyExceptionListener implements ExceptionListener{
+
+	@Logging
+	Logger LOGGER;
+	
+	@Override
+	public void onException(JMSException exception) {
+		LOGGER.info(exception.getMessage(), exception);
+	}
+
+}

--- a/jms-support/core/src/it/resources/META-INF/configuration/org.seedstack.seed.jms.props
+++ b/jms-support/core/src/it/resources/META-INF/configuration/org.seedstack.seed.jms.props
@@ -9,7 +9,7 @@
 #
 
 [org.seedstack.seed.jms]
-connection-factories = connectionFactory1, connectionFactory2, connectionFactory3, connectionFactory4, connectionFactory5
+connection-factories = connectionFactory1, connectionFactory2, connectionFactory3, connectionFactory4, connectionFactory5, connectionFactory6
 connection-factory.connectionFactory1.vendor.class = org.apache.activemq.ActiveMQConnectionFactory
 connection-factory.connectionFactory1.vendor.property.brokerURL = vm://localhost?broker.persistent=false
 connection-factory.connectionFactory2.vendor.class = org.apache.activemq.ActiveMQConnectionFactory
@@ -20,8 +20,10 @@ connection-factory.connectionFactory4.vendor.class = org.apache.activemq.ActiveM
 connection-factory.connectionFactory4.vendor.property.brokerURL = vm://localhost?broker.persistent=false
 connection-factory.connectionFactory5.vendor.class = org.apache.activemq.ActiveMQConnectionFactory
 connection-factory.connectionFactory5.vendor.property.brokerURL = vm://localhost?broker.persistent=false
+connection-factory.connectionFactory6.vendor.class = org.apache.activemq.ActiveMQConnectionFactory
+connection-factory.connectionFactory6.vendor.property.brokerURL = vm://localhost?broker.persistent=false
 #tcp://localhost:61616
-connections = connection1, connection2, connection3, connection4, connection5
+connections = connection1, connection2, connection3, connection4, connection5, connection6
 connection.connection1.connection-factory = connectionFactory1
 connection.connection1.reconnection-delay=100
 connection.connection2.connection-factory = connectionFactory2
@@ -32,5 +34,7 @@ connection.connection4.connection-factory = connectionFactory4
 connection.connection4.reconnection-delay=100
 connection.connection5.connection-factory = connectionFactory5
 connection.connection5.reconnection-delay=100
-
+connection.connection6.connection-factory = connectionFactory6
+connection.connection6.reconnection-delay=3000
+connection.connection6.exceptionListener=org.seedstack.seed.jms.internal.MyExceptionListener
 

--- a/jms-support/core/src/test/java/org/seedstack/seed/jms/internal/ManagedConnectionTest.java
+++ b/jms-support/core/src/test/java/org/seedstack/seed/jms/internal/ManagedConnectionTest.java
@@ -10,6 +10,7 @@
 package org.seedstack.seed.jms.internal;
 
 import com.google.common.collect.Lists;
+
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,6 +23,7 @@ import org.seedstack.seed.jms.spi.ConnectionDefinition;
 
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
+import javax.jms.ExceptionListener;
 import javax.jms.JMSException;
 import javax.jms.Session;
 
@@ -59,6 +61,13 @@ public class ManagedConnectionTest {
 
         // Failure
         Whitebox.setInternalState(underTest, "connectionFactory", new FakeConnectionFactory());
+        underTest.setExceptionListener(new ExceptionListener() {
+			
+			@Override
+			public void onException(JMSException exception) {
+				
+			}
+		});
         underTest.onException(new JMSException("Connection closed"));
 
         // Reset 


### PR DESCRIPTION
Fixes #2

Add a declarative way to register a JMS `ExceptionListener` by filling the qualifed name of you `Listener` for the property `exceptionListener` of your connection : 
```
org.seedstack.seed.jms.connection.myConnection.exceptionListener = myPackage.myExceptionListener
```
