### PR TITLE
Fixes #67 wrong import in security interceptors

### DIFF
--- a/security-support/core/src/main/java/org/seedstack/seed/security/internal/authorization/RequiresPermissionsInterceptor.java
+++ b/security-support/core/src/main/java/org/seedstack/seed/security/internal/authorization/RequiresPermissionsInterceptor.java
@@ -9,12 +9,12 @@
  */
 package org.seedstack.seed.security.internal.authorization;
 
-import org.seedstack.seed.security.api.SecuritySupport;
-import org.seedstack.seed.security.api.annotations.RequiresPermissions;
-import org.seedstack.seed.security.api.exceptions.AuthorizationException;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
-import org.apache.shiro.authz.annotation.Logical;
+import org.seedstack.seed.security.api.SecuritySupport;
+import org.seedstack.seed.security.api.annotations.Logical;
+import org.seedstack.seed.security.api.annotations.RequiresPermissions;
+import org.seedstack.seed.security.api.exceptions.AuthorizationException;
 
 import java.lang.annotation.Annotation;
 
@@ -49,11 +49,7 @@ public class RequiresPermissionsInterceptor implements MethodInterceptor {
         if (perms.length == 1) {
             securitySupport.checkPermission(perms[0]);
             return invocation.proceed();
-        }
-        if (Logical.AND.equals(rpAnnotation.logical())) {
-            securitySupport.checkPermissions(perms);
-        }
-        if (Logical.OR.equals(rpAnnotation.logical())) {
+        } else if (Logical.OR.equals(rpAnnotation.logical())) {
             boolean hasAtLeastOnePermission = false;
             for (String permission : perms) {
                 if (securitySupport.isPermitted(permission)) {
@@ -64,6 +60,9 @@ public class RequiresPermissionsInterceptor implements MethodInterceptor {
             if (!hasAtLeastOnePermission) {
                 throw new AuthorizationException("User does not have any of the permissions to access method " + invocation.getMethod().toString());
             }
+        } else {
+            // Otherwise rrAnnotation.logical() is by default considered as Logical.AND
+            securitySupport.checkPermissions(perms);
         }
         return invocation.proceed();
     }

--- a/security-support/core/src/main/java/org/seedstack/seed/security/internal/authorization/RequiresRolesInterceptor.java
+++ b/security-support/core/src/main/java/org/seedstack/seed/security/internal/authorization/RequiresRolesInterceptor.java
@@ -9,12 +9,12 @@
  */
 package org.seedstack.seed.security.internal.authorization;
 
-import org.seedstack.seed.security.api.SecuritySupport;
-import org.seedstack.seed.security.api.annotations.RequiresRoles;
-import org.seedstack.seed.security.api.exceptions.AuthorizationException;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
-import org.apache.shiro.authz.annotation.Logical;
+import org.seedstack.seed.security.api.SecuritySupport;
+import org.seedstack.seed.security.api.annotations.Logical;
+import org.seedstack.seed.security.api.annotations.RequiresRoles;
+import org.seedstack.seed.security.api.exceptions.AuthorizationException;
 
 import java.lang.annotation.Annotation;
 
@@ -49,11 +49,7 @@ public class RequiresRolesInterceptor implements MethodInterceptor {
         if (roles.length == 1) {
             securitySupport.checkRole(roles[0]);
             return invocation.proceed();
-        }
-        if (Logical.AND.equals(rrAnnotation.logical())) {
-            securitySupport.checkRoles(roles);
-        }
-        if (Logical.OR.equals(rrAnnotation.logical())) {
+        } else if (Logical.OR.equals(rrAnnotation.logical())) {
             boolean hasAtLeastOneRole = false;
             for (String role : roles) {
                 if (securitySupport.hasRole(role)) {
@@ -64,6 +60,9 @@ public class RequiresRolesInterceptor implements MethodInterceptor {
             if (!hasAtLeastOneRole) {
                 throw new AuthorizationException("User does not have any of the roles to access method " + invocation.getMethod().toString());
             }
+        } else {
+            // Otherwise rrAnnotation.logical() is by default considered as Logical.AND
+            securitySupport.checkRoles(roles);
         }
         return invocation.proceed();
     }

--- a/security-support/core/src/test/java/org/seedstack/seed/security/internal/authorization/RequiresPermissionsInterceptorTest.java
+++ b/security-support/core/src/test/java/org/seedstack/seed/security/internal/authorization/RequiresPermissionsInterceptorTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.security.internal.authorization;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.seedstack.seed.security.api.SecuritySupport;
+import org.seedstack.seed.security.api.annotations.Logical;
+import org.seedstack.seed.security.api.annotations.RequiresPermissions;
+import org.seedstack.seed.security.api.exceptions.AuthorizationException;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class RequiresPermissionsInterceptorTest {
+
+    private RequiresPermissionsInterceptor underTest;
+
+    @Test
+    public void test_one_permission_ok() throws Throwable {
+        SecuritySupport securitySupport = Mockito.mock(SecuritySupport.class);
+        underTest = new RequiresPermissionsInterceptor(securitySupport);
+
+        MethodInvocation methodInvocation = Mockito.mock(MethodInvocation.class);
+        when(methodInvocation.getMethod()).thenReturn(RequiresPermissionsInterceptorTest.class.getMethod("securedMethod"));
+
+        underTest.invoke(methodInvocation);
+    }
+
+    @Test(expected = AuthorizationException.class)
+    public void test_one_permission_fail() throws Throwable {
+        SecuritySupport securitySupport = Mockito.mock(SecuritySupport.class);
+        Mockito.doThrow(new AuthorizationException()).when(securitySupport).checkPermission("CODE");
+
+        underTest = new RequiresPermissionsInterceptor(securitySupport);
+        MethodInvocation methodInvocation = Mockito.mock(MethodInvocation.class);
+
+        when(methodInvocation.getMethod()).thenReturn(RequiresPermissionsInterceptorTest.class.getMethod("securedMethod"));
+        underTest.invoke(methodInvocation);
+    }
+
+    @Test
+    public void test_or_permission_ok() throws Throwable {
+        SecuritySupport securitySupport = Mockito.mock(SecuritySupport.class);
+        Mockito.when(securitySupport.isPermitted("CODE")).thenReturn(true);
+        Mockito.when(securitySupport.isPermitted("EAT")).thenReturn(false);
+
+        underTest = new RequiresPermissionsInterceptor(securitySupport);
+        MethodInvocation methodInvocation = Mockito.mock(MethodInvocation.class);
+
+        when(methodInvocation.getMethod()).thenReturn(RequiresPermissionsInterceptorTest.class.getMethod("securedOrMethod"));
+        underTest.invoke(methodInvocation);
+    }
+
+    @Test(expected = AuthorizationException.class)
+    public void test_or_permission_fail() throws Throwable {
+        SecuritySupport securitySupport = Mockito.mock(SecuritySupport.class);
+        Mockito.when(securitySupport.isPermitted("CODE")).thenReturn(false);
+        Mockito.when(securitySupport.isPermitted("EAT")).thenReturn(false);
+
+        underTest = new RequiresPermissionsInterceptor(securitySupport);
+        MethodInvocation methodInvocation = Mockito.mock(MethodInvocation.class);
+
+        when(methodInvocation.getMethod()).thenReturn(RequiresPermissionsInterceptorTest.class.getMethod("securedOrMethod"));
+        underTest.invoke(methodInvocation);
+    }
+
+    @Test
+    public void test_and_permission_ok() throws Throwable {
+        SecuritySupport securitySupport = Mockito.mock(SecuritySupport.class);
+        Mockito.when(securitySupport.isPermitted("CODE")).thenReturn(true);
+        Mockito.when(securitySupport.isPermitted("EAT")).thenReturn(true);
+
+        underTest = new RequiresPermissionsInterceptor(securitySupport);
+        MethodInvocation methodInvocation = Mockito.mock(MethodInvocation.class);
+
+        when(methodInvocation.getMethod()).thenReturn(RequiresPermissionsInterceptorTest.class.getMethod("securedAndMethod"));
+        underTest.invoke(methodInvocation);
+    }
+
+    @Test(expected = AuthorizationException.class)
+    public void test_and_permission_fail() throws Throwable {
+        SecuritySupport securitySupport = Mockito.mock(SecuritySupport.class);
+        Mockito.doThrow(new AuthorizationException()).when(securitySupport).checkPermissions("CODE", "EAT");
+
+        underTest = new RequiresPermissionsInterceptor(securitySupport);
+        MethodInvocation methodInvocation = Mockito.mock(MethodInvocation.class);
+
+        when(methodInvocation.getMethod()).thenReturn(RequiresPermissionsInterceptorTest.class.getMethod("securedAndMethod"));
+        underTest.invoke(methodInvocation);
+    }
+
+    @RequiresPermissions("CODE")
+    public void securedMethod() {
+    }
+    @RequiresPermissions(value = {"CODE", "EAT"}, logical = Logical.OR)
+    public void securedOrMethod() {
+    }
+    @RequiresPermissions(value = {"CODE", "EAT"}, logical = Logical.AND)
+    public void securedAndMethod() {
+    }
+}

--- a/security-support/core/src/test/java/org/seedstack/seed/security/internal/authorization/RequiresRolesInterceptorTest.java
+++ b/security-support/core/src/test/java/org/seedstack/seed/security/internal/authorization/RequiresRolesInterceptorTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.security.internal.authorization;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.seedstack.seed.security.api.SecuritySupport;
+import org.seedstack.seed.security.api.annotations.Logical;
+import org.seedstack.seed.security.api.annotations.RequiresRoles;
+import org.seedstack.seed.security.api.exceptions.AuthorizationException;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class RequiresRolesInterceptorTest {
+
+    private RequiresRolesInterceptor underTest;
+
+    @Test
+    public void test_one_permission_ok() throws Throwable {
+        SecuritySupport securitySupport = Mockito.mock(SecuritySupport.class);
+        underTest = new RequiresRolesInterceptor(securitySupport);
+
+        MethodInvocation methodInvocation = Mockito.mock(MethodInvocation.class);
+        when(methodInvocation.getMethod()).thenReturn(RequiresRolesInterceptorTest.class.getMethod("securedMethod"));
+
+        underTest.invoke(methodInvocation);
+    }
+
+    @Test(expected = AuthorizationException.class)
+    public void test_one_permission_fail() throws Throwable {
+        SecuritySupport securitySupport = Mockito.mock(SecuritySupport.class);
+        Mockito.doThrow(new AuthorizationException()).when(securitySupport).checkRole("CODE");
+
+        underTest = new RequiresRolesInterceptor(securitySupport);
+        MethodInvocation methodInvocation = Mockito.mock(MethodInvocation.class);
+
+        when(methodInvocation.getMethod()).thenReturn(RequiresRolesInterceptorTest.class.getMethod("securedMethod"));
+        underTest.invoke(methodInvocation);
+    }
+
+    @Test
+    public void test_or_permission_ok() throws Throwable {
+        SecuritySupport securitySupport = Mockito.mock(SecuritySupport.class);
+        Mockito.when(securitySupport.hasRole("CODE")).thenReturn(true);
+        Mockito.when(securitySupport.hasRole("EAT")).thenReturn(false);
+
+        underTest = new RequiresRolesInterceptor(securitySupport);
+        MethodInvocation methodInvocation = Mockito.mock(MethodInvocation.class);
+
+        when(methodInvocation.getMethod()).thenReturn(RequiresRolesInterceptorTest.class.getMethod("securedOrMethod"));
+        underTest.invoke(methodInvocation);
+    }
+
+    @Test(expected = AuthorizationException.class)
+    public void test_or_permission_fail() throws Throwable {
+        SecuritySupport securitySupport = Mockito.mock(SecuritySupport.class);
+        Mockito.when(securitySupport.hasRole("CODE")).thenReturn(false);
+        Mockito.when(securitySupport.hasRole("EAT")).thenReturn(false);
+
+        underTest = new RequiresRolesInterceptor(securitySupport);
+        MethodInvocation methodInvocation = Mockito.mock(MethodInvocation.class);
+
+        when(methodInvocation.getMethod()).thenReturn(RequiresRolesInterceptorTest.class.getMethod("securedOrMethod"));
+        underTest.invoke(methodInvocation);
+    }
+
+    @Test
+    public void test_and_permission_ok() throws Throwable {
+        SecuritySupport securitySupport = Mockito.mock(SecuritySupport.class);
+        Mockito.when(securitySupport.hasRole("CODE")).thenReturn(true);
+        Mockito.when(securitySupport.hasRole("EAT")).thenReturn(true);
+
+        underTest = new RequiresRolesInterceptor(securitySupport);
+        MethodInvocation methodInvocation = Mockito.mock(MethodInvocation.class);
+
+        when(methodInvocation.getMethod()).thenReturn(RequiresRolesInterceptorTest.class.getMethod("securedAndMethod"));
+        underTest.invoke(methodInvocation);
+    }
+
+    @Test(expected = AuthorizationException.class)
+    public void test_and_permission_fail() throws Throwable {
+        SecuritySupport securitySupport = Mockito.mock(SecuritySupport.class);
+        Mockito.doThrow(new AuthorizationException()).when(securitySupport).checkRoles("CODE", "EAT");
+
+        underTest = new RequiresRolesInterceptor(securitySupport);
+        MethodInvocation methodInvocation = Mockito.mock(MethodInvocation.class);
+
+        when(methodInvocation.getMethod()).thenReturn(RequiresRolesInterceptorTest.class.getMethod("securedAndMethod"));
+        underTest.invoke(methodInvocation);
+    }
+
+    @RequiresRoles("CODE")
+    public void securedMethod() {
+    }
+    @RequiresRoles(value = {"CODE", "EAT"}, logical = Logical.OR)
+    public void securedOrMethod() {
+    }
+    @RequiresRoles(value = {"CODE", "EAT"}, logical = Logical.AND)
+    public void securedAndMethod() {
+    }
+}


### PR DESCRIPTION
Change interceptor implementation to be more robust. Now `AND` is the default case.
Add unit tests on interceptors.