### PR TITLE
Add default ExceptionMapper

### DIFF
--- a/rest-support/core/pom.xml
+++ b/rest-support/core/pom.xml
@@ -28,6 +28,11 @@
         </dependency>
         <dependency>
             <groupId>org.seedstack.seed</groupId>
+            <artifactId>seed-security-support-specs</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seedstack.seed</groupId>
             <artifactId>seed-web-support-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/rest-support/core/src/it/java/org/seedstack/seed/rest/ErroneousResourceIT.java
+++ b/rest-support/core/src/it/java/org/seedstack/seed/rest/ErroneousResourceIT.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.json.JSONException;
+import org.junit.Test;
+import org.seedstack.seed.it.AbstractSeedWebIT;
+
+import java.net.URL;
+
+import static com.jayway.restassured.RestAssured.expect;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class ErroneousResourceIT extends AbstractSeedWebIT {
+
+    @ArquillianResource
+    private URL baseURL;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class).setWebXML("WEB-INF/web.xml");
+    }
+
+    @RunAsClient
+    @Test
+    public void test_exception_mappers() throws JSONException {
+        expect().statusCode(500).given().get(baseURL.toString() + "rest/error/internal");
+        expect().statusCode(401).given().get(baseURL.toString() + "rest/error/authentication");
+        expect().statusCode(403).given().get(baseURL.toString() + "rest/error/authorization");
+        expect().statusCode(404).given().get(baseURL.toString() + "rest/error/notFound");
+    }
+}

--- a/rest-support/core/src/it/java/org/seedstack/seed/rest/fixtures/ErroneousResource.java
+++ b/rest-support/core/src/it/java/org/seedstack/seed/rest/fixtures/ErroneousResource.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.fixtures;
+
+import com.sun.jersey.api.NotFoundException;
+import org.seedstack.seed.security.api.exceptions.AuthenticationException;
+import org.seedstack.seed.security.api.exceptions.AuthorizationException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+@Path("/error")
+public class ErroneousResource {
+
+    @GET
+    @Path("/internal")
+    public Response internalError() {
+        throw new RuntimeException();
+    }
+
+    @GET
+    @Path("/authentication")
+    public Response authentication() {
+        throw new AuthenticationException("");
+    }
+
+    @GET
+    @Path("/authorization")
+    public Response authorization() {
+        throw new AuthorizationException("");
+    }
+
+    @GET
+    @Path("/notFound")
+    public Response notFound() {
+        throw new NotFoundException();
+    }
+}

--- a/rest-support/core/src/main/java/org/seedstack/seed/rest/internal/SeedContainer.java
+++ b/rest-support/core/src/main/java/org/seedstack/seed/rest/internal/SeedContainer.java
@@ -14,6 +14,7 @@ import com.sun.jersey.api.core.DefaultResourceConfig;
 import com.sun.jersey.api.core.ResourceConfig;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
 import com.sun.jersey.spi.container.ResourceFilterFactory;
+import com.sun.jersey.spi.container.WebApplication;
 import com.sun.jersey.spi.container.servlet.WebConfig;
 
 import javax.inject.Inject;
@@ -29,6 +30,7 @@ class SeedContainer extends GuiceContainer {
     private static final long serialVersionUID = 1L;
 
     private final List<ResourceFilterFactory> resourceFilterFactories;
+    private final List<Class<?>> providers = new ArrayList<Class<?>>();
 
     @SuppressWarnings("all")
     @Inject
@@ -48,5 +50,24 @@ class SeedContainer extends GuiceContainer {
         ResourceConfig resourceConfig = new DefaultResourceConfig();
         resourceConfig.setPropertiesAndFeatures(propertiesAndFeatures);
         return resourceConfig;
+    }
+
+    @Override
+    protected void initiate(ResourceConfig config, WebApplication webapp) {
+        config.getClasses().addAll(providers);
+        super.initiate(config, webapp);
+    }
+
+    /**
+     * Registers a root resource and provider class.
+     * <p>
+     * The default lifecycle for resource class instances is per-request.
+     * The default lifecycle for providers is singleton.
+     * </p>
+     *
+     * @param aClass the class to register
+     */
+    public void registerClass(Class<?> aClass) {
+        providers.add(aClass);
     }
 }

--- a/rest-support/core/src/main/java/org/seedstack/seed/rest/internal/exceptionmapper/AuthenticationExceptionMapper.java
+++ b/rest-support/core/src/main/java/org/seedstack/seed/rest/internal/exceptionmapper/AuthenticationExceptionMapper.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.internal.exceptionmapper;
+
+import org.seedstack.seed.security.api.exceptions.AuthenticationException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * Default {@link AuthenticationException} exception mapper which returns an HTTP status 401 (unauthorized).
+ *
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class AuthenticationExceptionMapper implements ExceptionMapper<AuthenticationException> {
+    @Override
+    public Response toResponse(AuthenticationException exception) {
+        return Response.status(Response.Status.UNAUTHORIZED).build();
+    }
+}

--- a/rest-support/core/src/main/java/org/seedstack/seed/rest/internal/exceptionmapper/AuthorizationExceptionMapper.java
+++ b/rest-support/core/src/main/java/org/seedstack/seed/rest/internal/exceptionmapper/AuthorizationExceptionMapper.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.internal.exceptionmapper;
+
+import org.seedstack.seed.security.api.exceptions.AuthorizationException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * Default {@link AuthorizationException} exception mapper which returns an HTTP status 403 (forbidden).
+ *
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class AuthorizationExceptionMapper implements ExceptionMapper<AuthorizationException> {
+    @Override
+    public Response toResponse(AuthorizationException exception) {
+        return Response.status(Response.Status.FORBIDDEN).build();
+    }
+}

--- a/rest-support/core/src/main/java/org/seedstack/seed/rest/internal/exceptionmapper/InternalErrorExceptionMapper.java
+++ b/rest-support/core/src/main/java/org/seedstack/seed/rest/internal/exceptionmapper/InternalErrorExceptionMapper.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.internal.exceptionmapper;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * Default exception mapper for an caught exception with no exception mapper associated.
+ * It returns an HTTP status 500 (internal server error).
+ *
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class InternalErrorExceptionMapper implements ExceptionMapper<Exception> {
+
+    @Override
+    public Response toResponse(Exception exception) {
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    }
+}

--- a/rest-support/core/src/main/java/org/seedstack/seed/rest/internal/exceptionmapper/WebApplicationExcetionMapper.java
+++ b/rest-support/core/src/main/java/org/seedstack/seed/rest/internal/exceptionmapper/WebApplicationExcetionMapper.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.internal.exceptionmapper;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class WebApplicationExcetionMapper implements ExceptionMapper<WebApplicationException> {
+
+    @Override
+    public Response toResponse(WebApplicationException exception) {
+        return exception.getResponse();
+    }
+}


### PR DESCRIPTION
Add default ExceptionMapper for:

* Throwable
* AuthorizationException
* AuthenticationException

These ExceptionHandlers can be disabled with the following property:

    [org.seedstack.seed.rest]
    disableDefaultExceptionHanlders = true

In order to implement this feature, I also added an SPI to programmatically register root resource classes or providers.

    @Inject
    private SeedContainer container;

    ...

    container.registerClass(MyExceptionHandler.class);