### PR TITLE
HAL: apply the array unwrap only on _links

### DIFF
--- a/rest-support/core/src/main/java/org/seedstack/seed/rest/internal/hal/HalMessageBodyWriter.java
+++ b/rest-support/core/src/main/java/org/seedstack/seed/rest/internal/hal/HalMessageBodyWriter.java
@@ -11,7 +11,6 @@ package org.seedstack.seed.rest.internal.hal;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import org.seedstack.seed.rest.api.hal.HalRepresentation;
 
 import javax.ws.rs.WebApplicationException;
@@ -43,8 +42,7 @@ public class HalMessageBodyWriter implements MessageBodyWriter<HalRepresentation
 
     @Override
     public void writeTo(HalRepresentation halRepresentation, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
-        ObjectMapper objectMapper = new ObjectMapper()
-                .enable(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED);
+        ObjectMapper objectMapper = new ObjectMapper();
         try {
             entityStream.write(objectMapper.writeValueAsBytes(halRepresentation));
             entityStream.flush();

--- a/rest-support/core/src/test/java/org/seedstack/seed/rest/internal/hal/HalBuilderTest.java
+++ b/rest-support/core/src/test/java/org/seedstack/seed/rest/internal/hal/HalBuilderTest.java
@@ -11,6 +11,7 @@ package org.seedstack.seed.rest.internal.hal;
 
 import org.junit.Test;
 import org.seedstack.seed.rest.api.hal.HalDefaultRepresentation;
+import org.seedstack.seed.rest.api.hal.Link;
 import org.seedstack.seed.rest.internal.hal.fixture.OrderRepresentation;
 import org.seedstack.seed.rest.internal.hal.fixture.OrdersRepresentation;
 import org.seedstack.seed.rest.internal.hal.fixture.RepresentationFactory;
@@ -37,10 +38,10 @@ public class HalBuilderTest {
         assertThat(((OrdersRepresentation) halRep.getResource()).getShippedToday()).isEqualTo(20);
 
         assertThat(halRep.getLinks()).hasSize(3);
-        assertThat(halRep.getLinks().get("self").get(0).getHref()).isEqualTo("/rest/orders");
-        assertThat(halRep.getLinks().get("next").get(0).getHref()).isEqualTo("/rest/orders?page=2");
-        assertThat(halRep.getLinks().get("find").get(0).getHref()).isEqualTo("/rest/orders{?id}");
-        assertThat(halRep.getLinks().get("find").get(0).isTemplated()).isTrue();
+        assertThat(((Link) halRep.getLink("self")).getHref()).isEqualTo("/rest/orders");
+        assertThat(((Link)halRep.getLink("next")).getHref()).isEqualTo("/rest/orders?page=2");
+        assertThat(((Link)halRep.getLink("find")).getHref()).isEqualTo("/rest/orders{?id}");
+        assertThat(((Link)halRep.getLink("find")).isTemplated()).isTrue();
 
         assertThat(halRep.getEmbedded()).isNotNull();
         assertThat((List) halRep.getEmbedded().get("orders")).hasSize(2);
@@ -48,9 +49,9 @@ public class HalBuilderTest {
         // check embedded 1
         HalDefaultRepresentation halRep1 = ((HalDefaultRepresentation) ((List) halRep.getEmbedded().get("orders")).get(0));
         assertThat(halRep1.getLinks()).hasSize(3);
-        assertThat(halRep1.getLinks().get("self").get(0).getHref()).isEqualTo("/rest/order/123");
-        assertThat(halRep1.getLinks().get("basket").get(0).getHref()).isEqualTo("/rest/baskets/98712");
-        assertThat(halRep1.getLinks().get("customer").get(0).getHref()).isEqualTo("/rest/customers/7809");
+        assertThat(((Link)halRep1.getLink("self")).getHref()).isEqualTo("/rest/order/123");
+        assertThat(((Link)halRep1.getLink("basket")).getHref()).isEqualTo("/rest/baskets/98712");
+        assertThat(((Link)halRep1.getLink("customer")).getHref()).isEqualTo("/rest/customers/7809");
 
         OrderRepresentation order1 = (OrderRepresentation) halRep1.getResource();
         assertThat(order1.getTotal()).isEqualTo(30.00f);
@@ -60,9 +61,9 @@ public class HalBuilderTest {
         // check embedded 2
         HalDefaultRepresentation halRep2 = ((HalDefaultRepresentation) ((List) halRep.getEmbedded().get("orders")).get(1));
         assertThat(halRep2.getLinks()).hasSize(3);
-        assertThat(halRep2.getLinks().get("self").get(0).getHref()).isEqualTo("/rest/order/124");
-        assertThat(halRep2.getLinks().get("basket").get(0).getHref()).isEqualTo("/rest/baskets/97213");
-        assertThat(halRep2.getLinks().get("customer").get(0).getHref()).isEqualTo("/rest/customers/12369");
+        assertThat(((Link)halRep2.getLink("self")).getHref()).isEqualTo("/rest/order/124");
+        assertThat(((Link)halRep2.getLink("basket")).getHref()).isEqualTo("/rest/baskets/97213");
+        assertThat(((Link)halRep2.getLink("customer")).getHref()).isEqualTo("/rest/customers/12369");
 
         OrderRepresentation order2 = (OrderRepresentation) halRep2.getResource();
         assertThat(order2.getTotal()).isEqualTo(20.00f);

--- a/rest-support/specs/pom.xml
+++ b/rest-support/specs/pom.xml
@@ -39,5 +39,12 @@
             <artifactId>handy-uri-templates</artifactId>
             <version>2.0.2</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.seedstack.seed</groupId>
+            <artifactId>seed-unittest-support</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/rest-support/specs/src/main/java/org/seedstack/seed/rest/api/hal/HalRepresentation.java
+++ b/rest-support/specs/src/main/java/org/seedstack/seed/rest/api/hal/HalRepresentation.java
@@ -53,9 +53,16 @@ import java.util.Map;
  */
 public class HalRepresentation {
 
+    /**
+     * Links as defined in the <a href="https://tools.ietf.org/html/draft-kelly-json-hal-06#section-4.1.1">specification</a>
+     * is a map whose keys are rel and values can be either an object link or an array of object links.
+     * <p>
+     * So Object can be a List&lt;Link&gt; or a {@link org.seedstack.seed.rest.api.hal.Link}
+     * </p>
+     */
     @JsonProperty("_links")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    private final Map<String, List<Link>> links = new HashMap<String, List<Link>>();
+    private final Map<String, Object> links = new HashMap<String, Object>();
 
     @JsonProperty("_embedded")
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
@@ -107,17 +114,35 @@ public class HalRepresentation {
      *
      * @return map of links
      */
-    public Map<String, List<Link>> getLinks() {
+    public Object getLink(String rel) {
+        return links.get(rel);
+    }
+
+    /**
+     * Returns the resource's links.
+     *
+     * @return map of links
+     */
+    public Map<String, Object> getLinks() {
         return links;
     }
 
     private void addLink(String rel, Link link) {
-        List<Link> linksForRel = links.get(rel);
-        if (linksForRel == null) {
-            linksForRel = new ArrayList<Link>();
+        Object obj = links.get(rel);
+        if (obj == null) {
+            links.put(rel, link);
+        } else if (obj instanceof List) {
+            //noinspection unchecked
+            List<Link> linksForRel = (List<Link>) obj;
+            linksForRel.add(link);
+            links.put(rel, linksForRel);
+        } else if (obj instanceof Link){
+            Link linkCopy = (Link) obj;
+            List<Link> linksForRel = new ArrayList<Link>();
+            linksForRel.add(linkCopy);
+            linksForRel.add(link);
+            links.put(rel, linksForRel);
         }
-        linksForRel.add(link);
-        links.put(rel, linksForRel);
     }
 
     /**

--- a/rest-support/specs/src/test/java/org/seedstack/seed/rest/api/hal/HalRepresentationTest.java
+++ b/rest-support/specs/src/test/java/org/seedstack/seed/rest/api/hal/HalRepresentationTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.api.hal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.util.Lists;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class HalRepresentationTest {
+
+    @Test
+    public void test_hal_links() {
+        HalRepresentation halRepresentation = new HalRepresentation();
+        halRepresentation.link("curies", new Link("http://docs.acme.com/relations/{rel}").templated().name("acme"));
+        Assertions.assertThat(halRepresentation.getLink("curies")).isInstanceOf(Link.class);
+        halRepresentation.link("curies", new Link("http://example.org/{rel}").templated().name("example"));
+        Assertions.assertThat(halRepresentation.getLink("curies")).isInstanceOf(List.class);
+        Assertions.assertThat(((List<?>) halRepresentation.getLink("curies"))).hasSize(2);
+        halRepresentation.link("curies", new Link("http://example2.org/{rel}").templated().name("example2"));
+        Assertions.assertThat(((List<?>) halRepresentation.getLink("curies"))).hasSize(3);
+    }
+
+    private static final String EXPECTED = "{\"_links\":{\"objects\":{\"href\":\"/pok\"}},\"_embedded\":{\"objects\":[{\"name\":\"toto\"}]}}";
+
+    static class Person {
+        @JsonProperty("name")
+        private String name;
+
+        public Person(String name) {
+            this.name = name;
+        }
+    }
+
+    @Test
+    public void test_hal_link_serialization() throws Exception {
+        HalRepresentation halRepresentation = new HalRepresentation();
+        halRepresentation.link("objects", "/pok");
+        halRepresentation.embedded("objects", Lists.newArrayList(new Person("toto")));
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ObjectMapper objectMapper = new ObjectMapper();
+        outputStream.write(objectMapper.writeValueAsBytes(halRepresentation));
+        outputStream.flush();
+
+        Assertions.assertThat(outputStream.toString()).isEqualTo(EXPECTED);
+    }
+}


### PR DESCRIPTION
The jackson property `SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED` was applied on all the serialized field.

This PR replace it by a custom behavior on links.