### PR TITLE
Add test scope to tomcat-embed-websocket

### DIFF
--- a/web-support/websocket/pom.xml
+++ b/web-support/websocket/pom.xml
@@ -53,6 +53,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-websocket</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
The test scope were missing for the `tomcat-embed-websocket` dependency.