### PR TITLE
Fix #124 Nuun facets

### DIFF
--- a/cli/src/main/java/org/seedstack/seed/cli/internal/CommandLinePlugin.java
+++ b/cli/src/main/java/org/seedstack/seed/cli/internal/CommandLinePlugin.java
@@ -18,7 +18,7 @@ import org.kametic.specifications.Specification;
 import org.seedstack.seed.cli.CliCommand;
 import org.seedstack.seed.cli.CommandLineHandler;
 import org.seedstack.seed.cli.spi.CliContext;
-import org.seedstack.seed.core.internal.application.ApplicationPlugin;
+import org.seedstack.seed.core.spi.configuration.ConfigurationProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +57,7 @@ public class CommandLinePlugin extends AbstractPlugin {
 
     @Override
     public Collection<Class<?>> requiredPlugins() {
-        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class);
+        return Lists.<Class<?>>newArrayList(ConfigurationProvider.class);
     }
 
     @Override
@@ -75,7 +75,7 @@ public class CommandLinePlugin extends AbstractPlugin {
             return InitState.INITIALIZED;
         }
 
-        Configuration cliConfiguration = ((ApplicationPlugin) initContext.pluginsRequired().iterator().next()).getApplication().getConfiguration().subset(CLI_PLUGIN_PREFIX);
+        Configuration cliConfiguration = initContext.dependency(ConfigurationProvider.class).getConfiguration().subset(CLI_PLUGIN_PREFIX);
         Collection<Class<?>> cliHandlerCandidates = initContext.scannedTypesBySpecification().get(cliHandlerSpec);
 
         for (Class<?> candidate : cliHandlerCandidates) {

--- a/cli/src/main/java/org/seedstack/seed/cli/internal/CommandLinePlugin.java
+++ b/cli/src/main/java/org/seedstack/seed/cli/internal/CommandLinePlugin.java
@@ -7,7 +7,7 @@
  */
 package org.seedstack.seed.cli.internal;
 
-import io.nuun.kernel.api.Plugin;
+import com.google.common.collect.Lists;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
@@ -22,14 +22,11 @@ import org.seedstack.seed.core.internal.application.ApplicationPlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.seedstack.seed.core.utils.BaseClassSpecifications.ancestorImplements;
-import static org.seedstack.seed.core.utils.BaseClassSpecifications.classIsAbstract;
-import static org.seedstack.seed.core.utils.BaseClassSpecifications.classIsInterface;
+import static org.seedstack.seed.core.utils.BaseClassSpecifications.*;
 
 /**
  * This plugin enables to run {@link CommandLineHandler} through
@@ -59,10 +56,8 @@ public class CommandLinePlugin extends AbstractPlugin {
     }
 
     @Override
-    public Collection<Class<? extends Plugin>> requiredPlugins() {
-        Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
-        plugins.add(ApplicationPlugin.class);
-        return plugins;
+    public Collection<Class<?>> requiredPlugins() {
+        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class);
     }
 
     @Override

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>io.nuun</groupId>
             <artifactId>kernel-core</artifactId>
-            <version>1.0.M6-SNAPSHOT</version>
+            <version>${nuun-kernel.version}</version>
         </dependency>
         <dependency>
             <groupId>org.sonatype.sisu.inject</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>io.nuun</groupId>
             <artifactId>kernel-core</artifactId>
-            <version>${nuun-kernel.version}</version>
+            <version>1.0.M6-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.sonatype.sisu.inject</groupId>

--- a/core/src/main/java/org/seedstack/seed/core/internal/LoggingTypeListener.java
+++ b/core/src/main/java/org/seedstack/seed/core/internal/LoggingTypeListener.java
@@ -11,7 +11,7 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.spi.TypeEncounter;
 import com.google.inject.spi.TypeListener;
 import org.seedstack.seed.Logging;
-import io.nuun.kernel.api.assertions.AssertUtils;
+import org.seedstack.seed.core.utils.SeedReflectionUtils;
 import org.slf4j.Logger;
 
 import java.lang.annotation.Annotation;
@@ -41,7 +41,7 @@ class LoggingTypeListener implements TypeListener {
 
     private boolean annotationPresent(Field field, Class<? extends Annotation> annoClass) {
         for (Annotation anno : field.getAnnotations()) {
-            if (AssertUtils.hasAnnotationDeep(anno.annotationType(), annoClass)) {
+            if (SeedReflectionUtils.hasAnnotationDeep(anno.annotationType(), annoClass)) {
                 return true;
             }
         }

--- a/core/src/main/java/org/seedstack/seed/core/internal/application/ApplicationPlugin.java
+++ b/core/src/main/java/org/seedstack/seed/core/internal/application/ApplicationPlugin.java
@@ -23,12 +23,12 @@ import org.seedstack.seed.Application;
 import org.seedstack.seed.SeedException;
 import org.seedstack.seed.core.internal.CorePlugin;
 import org.seedstack.seed.spi.configuration.ConfigurationLookup;
+import org.seedstack.seed.core.spi.configuration.ConfigurationProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -41,7 +41,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @author adrien.lauer@mpsa.com
  */
-public class ApplicationPlugin extends AbstractPlugin {
+public class ApplicationPlugin extends AbstractPlugin implements ConfigurationProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationPlugin.class);
 
     public static final String CONFIGURATION_PACKAGE = "META-INF.configuration";
@@ -78,7 +78,7 @@ public class ApplicationPlugin extends AbstractPlugin {
         // Setup application diagnostic collector
         ApplicationDiagnosticCollector applicationDiagnosticCollector = new ApplicationDiagnosticCollector();
         applicationDiagnosticCollector.setBasePackages(pluginPackageRoot());
-        ((CorePlugin) initContext.pluginsRequired().iterator().next()).registerDiagnosticCollector("org.seedstack.seed.core.application", applicationDiagnosticCollector);
+        initContext.dependency(CorePlugin.class).registerDiagnosticCollector("org.seedstack.seed.core.application", applicationDiagnosticCollector);
 
         // Retrieve all configuration resources
         Set<String> allConfigurationResources = Sets.newHashSet();
@@ -256,5 +256,15 @@ public class ApplicationPlugin extends AbstractPlugin {
         } catch (Exception e) {
             throw SeedException.wrap(e, ApplicationErrorCode.UNABLE_TO_INSTANTIATE_CONFIGURATION_LOOKUP).put("className", strLookupClass.getCanonicalName());
         }
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        return application.getConfiguration();
+    }
+
+    @Override
+    public Configuration getConfiguration(Class<?> clazz) {
+        return application.getConfiguration(clazz);
     }
 }

--- a/core/src/main/java/org/seedstack/seed/core/internal/application/ApplicationPlugin.java
+++ b/core/src/main/java/org/seedstack/seed/core/internal/application/ApplicationPlugin.java
@@ -7,8 +7,8 @@
  */
 package org.seedstack.seed.core.internal.application;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import io.nuun.kernel.api.Plugin;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
@@ -197,10 +197,8 @@ public class ApplicationPlugin extends AbstractPlugin {
     }
 
     @Override
-    public Collection<Class<? extends Plugin>> requiredPlugins() {
-        Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
-        plugins.add(CorePlugin.class);
-        return plugins;
+    public Collection<Class<?>> requiredPlugins() {
+        return Lists.<Class<?>>newArrayList(CorePlugin.class);
     }
 
     @Override

--- a/core/src/main/java/org/seedstack/seed/core/internal/data/DataPlugin.java
+++ b/core/src/main/java/org/seedstack/seed/core/internal/data/DataPlugin.java
@@ -8,12 +8,6 @@
 package org.seedstack.seed.core.internal.data;
 
 import com.google.common.collect.Lists;
-import org.seedstack.seed.DataManager;
-import org.seedstack.seed.SeedException;
-import org.seedstack.seed.DataExporter;
-import org.seedstack.seed.DataImporter;
-import org.seedstack.seed.DataSet;
-import io.nuun.kernel.api.Plugin;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.Context;
 import io.nuun.kernel.api.plugin.context.InitContext;
@@ -21,13 +15,9 @@ import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
 import io.nuun.kernel.core.AbstractPlugin;
 import org.apache.commons.configuration.Configuration;
 import org.kametic.specifications.Specification;
-import org.seedstack.seed.DataManager;
-import org.seedstack.seed.SeedException;
+import org.seedstack.seed.*;
 import org.seedstack.seed.core.internal.CorePlugin;
-import org.seedstack.seed.core.internal.application.ApplicationPlugin;
-import org.seedstack.seed.DataExporter;
-import org.seedstack.seed.DataImporter;
-import org.seedstack.seed.DataSet;
+import org.seedstack.seed.core.spi.configuration.ConfigurationProvider;
 import org.seedstack.seed.core.utils.SeedReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,8 +64,8 @@ public class DataPlugin extends AbstractPlugin {
     @SuppressWarnings("unchecked")
     @Override
     public InitState init(InitContext initContext) {
-        ApplicationPlugin applicationPlugin = (ApplicationPlugin) initContext.pluginsRequired().iterator().next();
-        Configuration configuration = applicationPlugin.getApplication().getConfiguration().subset(CorePlugin.CORE_PLUGIN_PREFIX);
+        Configuration configuration = initContext.dependency(ConfigurationProvider.class)
+                .getConfiguration().subset(CorePlugin.CORE_PLUGIN_PREFIX);
 
         String dataInitializationMode = configuration.getString("data-initialization", "auto");
         if ("auto".equals(dataInitializationMode)) {
@@ -174,7 +164,7 @@ public class DataPlugin extends AbstractPlugin {
 
     @Override
     public Collection<Class<?>> requiredPlugins() {
-        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class);
+        return Lists.<Class<?>>newArrayList(ConfigurationProvider.class);
     }
 
     @Override

--- a/core/src/main/java/org/seedstack/seed/core/internal/data/DataPlugin.java
+++ b/core/src/main/java/org/seedstack/seed/core/internal/data/DataPlugin.java
@@ -7,6 +7,7 @@
  */
 package org.seedstack.seed.core.internal.data;
 
+import com.google.common.collect.Lists;
 import org.seedstack.seed.DataManager;
 import org.seedstack.seed.SeedException;
 import org.seedstack.seed.DataExporter;
@@ -20,8 +21,13 @@ import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
 import io.nuun.kernel.core.AbstractPlugin;
 import org.apache.commons.configuration.Configuration;
 import org.kametic.specifications.Specification;
+import org.seedstack.seed.DataManager;
+import org.seedstack.seed.SeedException;
 import org.seedstack.seed.core.internal.CorePlugin;
 import org.seedstack.seed.core.internal.application.ApplicationPlugin;
+import org.seedstack.seed.DataExporter;
+import org.seedstack.seed.DataImporter;
+import org.seedstack.seed.DataSet;
 import org.seedstack.seed.core.utils.SeedReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +37,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -168,10 +173,8 @@ public class DataPlugin extends AbstractPlugin {
     }
 
     @Override
-    public Collection<Class<? extends Plugin>> requiredPlugins() {
-        Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
-        plugins.add(ApplicationPlugin.class);
-        return plugins;
+    public Collection<Class<?>> requiredPlugins() {
+        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class);
     }
 
     @Override

--- a/core/src/main/java/org/seedstack/seed/core/internal/jndi/JndiPlugin.java
+++ b/core/src/main/java/org/seedstack/seed/core/internal/jndi/JndiPlugin.java
@@ -14,7 +14,7 @@ import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.core.AbstractPlugin;
 import org.apache.commons.configuration.Configuration;
 import org.seedstack.seed.core.internal.CorePlugin;
-import org.seedstack.seed.core.internal.application.ApplicationPlugin;
+import org.seedstack.seed.core.spi.configuration.ConfigurationProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,8 +46,7 @@ public class JndiPlugin extends AbstractPlugin {
 
     @Override
     public InitState init(InitContext initContext) {
-        ApplicationPlugin applicationPlugin = (ApplicationPlugin) initContext.pluginsRequired().iterator().next();
-        Configuration configuration = applicationPlugin.getApplication().getConfiguration().subset(CorePlugin.CORE_PLUGIN_PREFIX);
+        Configuration configuration = initContext.dependency(ConfigurationProvider.class).getConfiguration().subset(CorePlugin.CORE_PLUGIN_PREFIX);
 
         // Default JNDI context
         try {
@@ -89,7 +88,7 @@ public class JndiPlugin extends AbstractPlugin {
 
     @Override
     public Collection<Class<?>> requiredPlugins() {
-        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class);
+        return Lists.<Class<?>>newArrayList(ConfigurationProvider.class);
     }
 
     @Override

--- a/core/src/main/java/org/seedstack/seed/core/internal/jndi/JndiPlugin.java
+++ b/core/src/main/java/org/seedstack/seed/core/internal/jndi/JndiPlugin.java
@@ -7,8 +7,8 @@
  */
 package org.seedstack.seed.core.internal.jndi;
 
+import com.google.common.collect.Lists;
 import org.seedstack.seed.SeedException;
-import io.nuun.kernel.api.Plugin;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.core.AbstractPlugin;
@@ -23,7 +23,10 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * Plugin that retrieve configured JNDI contexts.
@@ -85,10 +88,8 @@ public class JndiPlugin extends AbstractPlugin {
     }
 
     @Override
-    public Collection<Class<? extends Plugin>> requiredPlugins() {
-        Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
-        plugins.add(ApplicationPlugin.class);
-        return plugins;
+    public Collection<Class<?>> requiredPlugins() {
+        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class);
     }
 
     @Override

--- a/core/src/main/java/org/seedstack/seed/core/utils/SeedCheckUtils.java
+++ b/core/src/main/java/org/seedstack/seed/core/utils/SeedCheckUtils.java
@@ -9,13 +9,11 @@ package org.seedstack.seed.core.utils;
 
 import com.google.inject.ConfigurationException;
 import com.google.inject.Injector;
+import org.kametic.specifications.Specification;
 import org.seedstack.seed.ErrorCode;
 import org.seedstack.seed.SeedException;
-import org.apache.commons.collections.iterators.ArrayIterator;
-import org.kametic.specifications.Specification;
 
 import javax.inject.Inject;
-import java.util.Iterator;
 
 /**
  * Class with various check utilities.
@@ -106,13 +104,9 @@ public final class SeedCheckUtils {
             seedException = SeedException.createNew(errorCode);
         }
 
-        Iterator<String> it = new ArrayIterator(properties);
-        while (it.hasNext()) {
-            String key = it.next();
-            String value = "";
-            if (it.hasNext()) {
-                value = it.next();
-            }
+        for (int i = 0; i < properties.length; i = i + 2) {
+            String key = properties[i];
+            String value = properties[i+1];
             seedException.put(key, value);
         }
 

--- a/core/src/test/java/org/seedstack/seed/core/internal/application/ApplicationPluginTest.java
+++ b/core/src/test/java/org/seedstack/seed/core/internal/application/ApplicationPluginTest.java
@@ -101,9 +101,7 @@ public class ApplicationPluginTest {
         InitContext initContext = mock(InitContext.class);
         Map<String, Collection<String>> resources = new HashMap<String, Collection<String>>();
 
-        when(initContext.pluginsRequired()).thenReturn(new ArrayList() {{
-            add(mock(CorePlugin.class));
-        }});
+        when(initContext.dependency(CorePlugin.class)).thenReturn(mock(CorePlugin.class));
 
         Map<Class<? extends Annotation>, Collection<Class<?>>> scannedClassesByAnnotationClass = new HashMap<Class<? extends Annotation>, Collection<Class<?>>>();
         scannedClassesByAnnotationClass.put(ConfigurationLookup.class, new ArrayList<Class<?>>());

--- a/core/src/test/java/org/seedstack/seed/core/internal/jndi/JndiPluginTest.java
+++ b/core/src/test/java/org/seedstack/seed/core/internal/jndi/JndiPluginTest.java
@@ -13,14 +13,14 @@ import io.nuun.kernel.api.plugin.context.InitContext;
 import org.apache.commons.configuration.Configuration;
 import org.assertj.core.api.Assertions;
 import org.fest.reflect.core.Reflection;
+import org.fest.reflect.reference.TypeRef;
 import org.junit.Before;
 import org.junit.Test;
 import org.seedstack.seed.core.internal.CorePlugin;
 import org.seedstack.seed.core.internal.application.ApplicationPlugin;
+import org.seedstack.seed.core.spi.configuration.ConfigurationProvider;
 
 import javax.naming.Context;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
@@ -56,7 +56,7 @@ public class JndiPluginTest {
 
 	@Test
 	public void requiredPluginsTest() {
-		Assertions.assertThat(pluginUnderTest.requiredPlugins()).contains(ApplicationPlugin.class);
+		Assertions.assertThat(pluginUnderTest.requiredPlugins()).contains(ConfigurationProvider.class);
 	}
 
 	@Test
@@ -71,17 +71,8 @@ public class JndiPluginTest {
 		when(configuration.getStringArray("additional-jndi-contexts")).thenReturn(new String[]{nameTolookup});
 		when(configuration.getString("additional-jndi-context.test1")).thenReturn("/jndi-test1.properties");
 		ApplicationPlugin applicationPlugin = mock(ApplicationPlugin.class);
-		Application application = mock(Application.class);
-		when(applicationPlugin.getApplication()).thenReturn(application);
-		when(application.getConfiguration()).thenReturn(configuration);
-		Collection plugins = mock(Collection.class);
-		Iterator iterator = mock(Iterator.class);
-		when(initContext.pluginsRequired()).thenReturn(plugins);
-		when(initContext.pluginsRequired().iterator()).thenReturn(iterator);
-		when((ApplicationPlugin) initContext.pluginsRequired().iterator().next()).thenReturn(applicationPlugin);
-		Assertions.assertThat(initContext).isNotNull();
-		Assertions.assertThat(applicationPlugin).isNotNull();
-		Assertions.assertThat(configuration).isNotNull();
+		when(initContext.dependency(ConfigurationProvider.class)).thenReturn(applicationPlugin);
+        when(applicationPlugin.getConfiguration()).thenReturn(configuration);
 		return initContext;
 	}
 

--- a/crypto/src/main/java/org/seedstack/seed/crypto/internal/CryptoPlugin.java
+++ b/crypto/src/main/java/org/seedstack/seed/crypto/internal/CryptoPlugin.java
@@ -9,6 +9,7 @@ package org.seedstack.seed.crypto.internal;
 
 import com.google.inject.Key;
 import io.nuun.kernel.api.Plugin;
+import com.google.common.collect.Lists;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.PluginException;
 import io.nuun.kernel.api.plugin.context.InitContext;
@@ -74,7 +75,7 @@ public class CryptoPlugin extends AbstractPlugin implements SSLProvider {
 
     @Override
     public InitState init(InitContext initContext) {
-        Plugin applicationPlugin = initContext.pluginsRequired().iterator().next();
+        Object applicationPlugin = initContext.pluginsRequired().iterator().next();
         if (!(applicationPlugin instanceof ApplicationPlugin)) {
             throw new PluginException("Missing ApplicationPlugin");
         }
@@ -196,9 +197,7 @@ public class CryptoPlugin extends AbstractPlugin implements SSLProvider {
     }
 
     @Override
-    public Collection<Class<? extends Plugin>> requiredPlugins() {
-        Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
-        plugins.add(ApplicationPlugin.class);
-        return plugins;
+    public Collection<Class<?>> requiredPlugins() {
+        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class);
     }
 }

--- a/crypto/src/main/java/org/seedstack/seed/crypto/internal/CryptoPlugin.java
+++ b/crypto/src/main/java/org/seedstack/seed/crypto/internal/CryptoPlugin.java
@@ -75,12 +75,7 @@ public class CryptoPlugin extends AbstractPlugin implements SSLProvider {
 
     @Override
     public InitState init(InitContext initContext) {
-        Object applicationPlugin = initContext.pluginsRequired().iterator().next();
-        if (!(applicationPlugin instanceof ApplicationPlugin)) {
-            throw new PluginException("Missing ApplicationPlugin");
-        }
-
-        Application application = ((ApplicationPlugin) applicationPlugin).getApplication();
+        Application application = initContext.dependency(ApplicationPlugin.class).getApplication();
         Configuration cryptoConfig = application.getConfiguration().subset(CONFIG_PREFIX);
 
         // Retrieve key store configurations

--- a/crypto/src/main/java/org/seedstack/seed/crypto/spi/SSLProvider.java
+++ b/crypto/src/main/java/org/seedstack/seed/crypto/spi/SSLProvider.java
@@ -7,6 +7,8 @@
  */
 package org.seedstack.seed.crypto.spi;
 
+import io.nuun.kernel.api.annotations.Facet;
+
 import javax.net.ssl.SSLContext;
 
 /**
@@ -14,6 +16,7 @@ import javax.net.ssl.SSLContext;
  *
  * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
  */
+@Facet
 public interface SSLProvider {
 
     /**

--- a/crypto/src/test/java/org/seedstack/seed/crypto/internal/CryptoPluginTest.java
+++ b/crypto/src/test/java/org/seedstack/seed/crypto/internal/CryptoPluginTest.java
@@ -14,7 +14,6 @@
 package org.seedstack.seed.crypto.internal;
 
 import com.google.inject.Key;
-import io.nuun.kernel.api.Plugin;
 import mockit.Deencapsulation;
 import mockit.Mocked;
 import mockit.Verifications;
@@ -74,7 +73,7 @@ public class CryptoPluginTest {
     @Test
     public void testRequiredPlugins() {
         CryptoPlugin plugin = new CryptoPlugin();
-        Collection<Class<? extends Plugin>> list = plugin.requiredPlugins();
+        Collection<Class<?>> list = plugin.requiredPlugins();
         Assertions.assertThat(list.contains(ApplicationPlugin.class)).isTrue();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <properties>
         <poms.version>2.1.0-SNAPSHOT</poms.version>
-        <nuun-kernel.version>1.0.M5</nuun-kernel.version>
+        <nuun-kernel.version>1.0.M6</nuun-kernel.version>
         <commons-configuration.version>1.9</commons-configuration.version>
         <commons-cli.version>1.2</commons-cli.version>
         <guice.version>3.1.3</guice.version>

--- a/rest/jersey1/src/it/java/org/seedstack/seed/rest/fixtures/RestTestPlugin.java
+++ b/rest/jersey1/src/it/java/org/seedstack/seed/rest/fixtures/RestTestPlugin.java
@@ -7,7 +7,7 @@
  */
 package org.seedstack.seed.rest.fixtures;
 
-import io.nuun.kernel.api.Plugin;
+import com.google.common.collect.Lists;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.core.AbstractPlugin;
@@ -15,28 +15,23 @@ import org.seedstack.seed.rest.internal.RestPlugin;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Variant;
-import java.util.ArrayList;
 import java.util.Collection;
 
 public class RestTestPlugin extends AbstractPlugin {
     @Override
     public String name() {
-        return "rest-test-plugin";
+        return "rest-test";
     }
 
     @Override
     public InitState init(InitContext initContext) {
-        RestPlugin restPlugin = (RestPlugin) initContext.pluginsRequired().iterator().next();
-
+        RestPlugin restPlugin = initContext.dependency(RestPlugin.class);
         restPlugin.registerRootResource(new Variant(MediaType.TEXT_HTML_TYPE, null, null), HTMLRootSubResource.class);
-
         return InitState.INITIALIZED;
     }
 
     @Override
-    public Collection<Class<? extends Plugin>> requiredPlugins() {
-        Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
-        plugins.add(RestPlugin.class);
-        return plugins;
+    public Collection<Class<?>> requiredPlugins() {
+        return Lists.<Class<?>>newArrayList(RestPlugin.class);
     }
 }

--- a/rest/jersey1/src/main/java/org/seedstack/seed/rest/internal/RestPlugin.java
+++ b/rest/jersey1/src/main/java/org/seedstack/seed/rest/internal/RestPlugin.java
@@ -19,7 +19,7 @@ import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
 import io.nuun.kernel.core.AbstractPlugin;
 import org.apache.commons.configuration.Configuration;
 import org.kametic.specifications.Specification;
-import org.seedstack.seed.core.internal.application.ApplicationPlugin;
+import org.seedstack.seed.core.spi.configuration.ConfigurationProvider;
 import org.seedstack.seed.core.utils.SeedConfigurationUtils;
 import org.seedstack.seed.rest.RelRegistry;
 import org.seedstack.seed.rest.ResourceFiltering;
@@ -139,15 +139,8 @@ public class RestPlugin extends AbstractPlugin {
     }
 
     private void collectPlugins(InitContext initContext) {
-        restConfiguration = null;
-        webPlugin = null;
-        for (Object plugin : initContext.pluginsRequired()) {
-            if (plugin instanceof ApplicationPlugin) {
-                restConfiguration = ((ApplicationPlugin) plugin).getApplication().getConfiguration().subset(RestPlugin.REST_PLUGIN_CONFIGURATION_PREFIX);
-            } else if (plugin instanceof WebPlugin) {
-                webPlugin = (WebPlugin) plugin;
-            }
-        }
+        restConfiguration = initContext.dependency(ConfigurationProvider.class).getConfiguration().subset(RestPlugin.REST_PLUGIN_CONFIGURATION_PREFIX);
+        webPlugin = initContext.dependency(WebPlugin.class);
 
         if (restConfiguration == null) {
             throw new PluginException("Unable to find SEED application plugin");
@@ -229,7 +222,7 @@ public class RestPlugin extends AbstractPlugin {
 
     @Override
     public Collection<Class<?>> requiredPlugins() {
-        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class, WebPlugin.class);
+        return Lists.<Class<?>>newArrayList(ConfigurationProvider.class, WebPlugin.class);
     }
 
     public void registerRootResource(Variant variant, Class<? extends RootResource> rootResource) {

--- a/rest/jersey1/src/main/java/org/seedstack/seed/rest/internal/RestPlugin.java
+++ b/rest/jersey1/src/main/java/org/seedstack/seed/rest/internal/RestPlugin.java
@@ -7,10 +7,10 @@
  */
 package org.seedstack.seed.rest.internal;
 
+import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.sun.jersey.spi.container.ResourceFilterFactory;
-import io.nuun.kernel.api.Plugin;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.PluginException;
 import io.nuun.kernel.api.plugin.context.Context;
@@ -141,7 +141,7 @@ public class RestPlugin extends AbstractPlugin {
     private void collectPlugins(InitContext initContext) {
         restConfiguration = null;
         webPlugin = null;
-        for (Plugin plugin : initContext.pluginsRequired()) {
+        for (Object plugin : initContext.pluginsRequired()) {
             if (plugin instanceof ApplicationPlugin) {
                 restConfiguration = ((ApplicationPlugin) plugin).getApplication().getConfiguration().subset(RestPlugin.REST_PLUGIN_CONFIGURATION_PREFIX);
             } else if (plugin instanceof WebPlugin) {
@@ -228,11 +228,8 @@ public class RestPlugin extends AbstractPlugin {
     }
 
     @Override
-    public Collection<Class<? extends Plugin>> requiredPlugins() {
-        Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
-        plugins.add(ApplicationPlugin.class);
-        plugins.add(WebPlugin.class);
-        return plugins;
+    public Collection<Class<?>> requiredPlugins() {
+        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class, WebPlugin.class);
     }
 
     public void registerRootResource(Variant variant, Class<? extends RootResource> rootResource) {

--- a/security/core/src/main/java/org/seedstack/seed/security/internal/SecurityPlugin.java
+++ b/security/core/src/main/java/org/seedstack/seed/security/internal/SecurityPlugin.java
@@ -17,6 +17,7 @@ import io.nuun.kernel.core.AbstractPlugin;
 import org.apache.commons.configuration.Configuration;
 import org.seedstack.seed.SeedException;
 import org.seedstack.seed.core.internal.application.ApplicationPlugin;
+import org.seedstack.seed.core.spi.configuration.ConfigurationProvider;
 import org.seedstack.seed.core.utils.SeedReflectionUtils;
 import org.seedstack.seed.el.internal.ELPlugin;
 import org.seedstack.seed.security.*;
@@ -65,13 +66,8 @@ public class SecurityPlugin extends AbstractPlugin {
     @Override
     @SuppressWarnings({"rawtypes", "unchecked"})
     public InitState init(InitContext initContext) {
-        for (Object plugin : initContext.pluginsRequired()) {
-            if (plugin instanceof ApplicationPlugin) {
-                securityConfiguration = ((ApplicationPlugin) plugin).getApplication().getConfiguration().subset(SECURITY_PREFIX);
-            } else if (plugin instanceof ELPlugin) {
-                elDisabled = ((ELPlugin) plugin).isDisabled();
-            }
-        }
+        securityConfiguration = initContext.dependency(ConfigurationProvider.class).getConfiguration().subset(SECURITY_PREFIX);
+        elDisabled = initContext.dependency(ELPlugin.class).isDisabled();
 
         scannedClasses = initContext.scannedSubTypesByAncestorClass();
         principalCustomizerClasses = (Collection) scannedClasses.get(PrincipalCustomizer.class);
@@ -126,7 +122,7 @@ public class SecurityPlugin extends AbstractPlugin {
 
     @Override
     public Collection<Class<?>> requiredPlugins() {
-        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class, ELPlugin.class);
+        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class, ConfigurationProvider.class, ELPlugin.class);
     }
 
     @Override

--- a/security/core/src/main/java/org/seedstack/seed/security/internal/SecurityPlugin.java
+++ b/security/core/src/main/java/org/seedstack/seed/security/internal/SecurityPlugin.java
@@ -7,7 +7,7 @@
  */
 package org.seedstack.seed.security.internal;
 
-import io.nuun.kernel.api.Plugin;
+import com.google.common.collect.Lists;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.api.plugin.request.BindingRequest;
@@ -65,7 +65,7 @@ public class SecurityPlugin extends AbstractPlugin {
     @Override
     @SuppressWarnings({"rawtypes", "unchecked"})
     public InitState init(InitContext initContext) {
-        for (Plugin plugin : initContext.pluginsRequired()) {
+        for (Object plugin : initContext.pluginsRequired()) {
             if (plugin instanceof ApplicationPlugin) {
                 securityConfiguration = ((ApplicationPlugin) plugin).getApplication().getConfiguration().subset(SECURITY_PREFIX);
             } else if (plugin instanceof ELPlugin) {
@@ -125,11 +125,8 @@ public class SecurityPlugin extends AbstractPlugin {
     }
 
     @Override
-    public Collection<Class<? extends Plugin>> requiredPlugins() {
-        Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
-        plugins.add(ApplicationPlugin.class);
-        plugins.add(ELPlugin.class);
-        return plugins;
+    public Collection<Class<?>> requiredPlugins() {
+        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class, ELPlugin.class);
     }
 
     @Override

--- a/security/core/src/test/java/org/seedstack/seed/security/internal/SecurityProviderTest.java
+++ b/security/core/src/test/java/org/seedstack/seed/security/internal/SecurityProviderTest.java
@@ -7,7 +7,6 @@
  */
 package org.seedstack.seed.security.internal;
 
-import io.nuun.kernel.api.Plugin;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import org.apache.commons.configuration.Configuration;
 import org.junit.Before;
@@ -41,7 +40,7 @@ public class SecurityProviderTest {
 
     @Test
     public void verify_dependencies() {
-        Collection<Class<? extends Plugin>> plugins = underTest.requiredPlugins();
+        Collection<Class<?>> plugins = underTest.requiredPlugins();
         assertTrue(plugins.contains(ApplicationPlugin.class));
     }
 

--- a/security/core/src/test/java/org/seedstack/seed/security/internal/SecurityProviderTest.java
+++ b/security/core/src/test/java/org/seedstack/seed/security/internal/SecurityProviderTest.java
@@ -11,8 +11,8 @@ import io.nuun.kernel.api.plugin.context.InitContext;
 import org.apache.commons.configuration.Configuration;
 import org.junit.Before;
 import org.junit.Test;
-import org.seedstack.seed.Application;
 import org.seedstack.seed.core.internal.application.ApplicationPlugin;
+import org.seedstack.seed.core.spi.configuration.ConfigurationProvider;
 import org.seedstack.seed.el.internal.ELPlugin;
 import org.seedstack.seed.security.Realm;
 import org.seedstack.seed.security.internal.realms.ConfigurationRealm;
@@ -29,8 +29,6 @@ import static org.mockito.Mockito.when;
 public class SecurityProviderTest {
 
     SecurityPlugin underTest;
-
-    SecurityProvider securityProvider;
     
     @Before
     public void before() {
@@ -41,7 +39,7 @@ public class SecurityProviderTest {
     @Test
     public void verify_dependencies() {
         Collection<Class<?>> plugins = underTest.requiredPlugins();
-        assertTrue(plugins.contains(ApplicationPlugin.class));
+        assertTrue(plugins.contains(ConfigurationProvider.class));
     }
 
     @Test
@@ -62,14 +60,10 @@ public class SecurityProviderTest {
         ApplicationPlugin appPlugin = mock(ApplicationPlugin.class);
         ELPlugin elPlugin = mock(ELPlugin.class);
         when(elPlugin.isDisabled()).thenReturn(false);
-        Application application = mock(Application.class);
         Configuration conf = mock(Configuration.class);
-        when(appPlugin.getApplication()).thenReturn(application);
-        when(application.getConfiguration()).thenReturn(conf);
-        Collection pluginsRequired = new ArrayList();
-        pluginsRequired.add(appPlugin);
-        pluginsRequired.add(elPlugin);
-        when(initContext.pluginsRequired()).thenReturn(pluginsRequired);
+        when(initContext.dependency(ConfigurationProvider.class)).thenReturn(appPlugin);
+        when(appPlugin.getConfiguration()).thenReturn(conf);
+        when(initContext.dependency(ELPlugin.class)).thenReturn(elPlugin);
 
         return initContext;
     }

--- a/shell/src/main/java/org/seedstack/seed/shell/internal/ShellPlugin.java
+++ b/shell/src/main/java/org/seedstack/seed/shell/internal/ShellPlugin.java
@@ -29,6 +29,7 @@ import org.apache.sshd.server.CommandFactory;
 import org.apache.sshd.server.UserAuth;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
+import org.seedstack.seed.Application;
 import org.seedstack.seed.core.internal.application.ApplicationPlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,8 +69,8 @@ public class ShellPlugin extends AbstractPlugin {
 
     @Override
     public InitState init(InitContext initContext) {
-        ApplicationPlugin applicationPlugin = (ApplicationPlugin) initContext.pluginsRequired().iterator().next();
-        org.apache.commons.configuration.Configuration shellConfiguration = applicationPlugin.getApplication().getConfiguration().subset(ShellPlugin.SHELL_PLUGIN_CONFIGURATION_PREFIX);
+        Application application = initContext.dependency(ApplicationPlugin.class).getApplication();
+        org.apache.commons.configuration.Configuration shellConfiguration = application.getConfiguration().subset(ShellPlugin.SHELL_PLUGIN_CONFIGURATION_PREFIX);
 
         // No need to go further if shell is not enabled
         if (!shellConfiguration.getBoolean("enabled", false)) {
@@ -83,7 +84,7 @@ public class ShellPlugin extends AbstractPlugin {
 
         String keyType = shellConfiguration.getString("key.type", "generated");
         if ("generated".equals(keyType)) {
-            File storage = applicationPlugin.getApplication().getStorageLocation("shell");
+            File storage = application.getStorageLocation("shell");
             sshServer.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(new File(storage, "generate-key.ser").getAbsolutePath()));
         } else if ("file".equals(keyType)) {
             sshServer.setKeyPairProvider(new FileKeyPairProvider(new String[]{shellConfiguration.getString("key.location")}));

--- a/shell/src/main/java/org/seedstack/seed/shell/internal/ShellPlugin.java
+++ b/shell/src/main/java/org/seedstack/seed/shell/internal/ShellPlugin.java
@@ -7,7 +7,7 @@
  */
 package org.seedstack.seed.shell.internal;
 
-import io.nuun.kernel.api.Plugin;
+import com.google.common.collect.Lists;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.PluginException;
 import io.nuun.kernel.api.plugin.context.Context;
@@ -145,10 +145,8 @@ public class ShellPlugin extends AbstractPlugin {
     }
 
     @Override
-    public Collection<Class<? extends Plugin>> requiredPlugins() {
-        Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
-        plugins.add(ApplicationPlugin.class);
-        return plugins;
+    public Collection<Class<?>> requiredPlugins() {
+        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class);
     }
 
     private final class ShiroAuthFactory implements NamedFactory<UserAuth> {

--- a/specs/pom.xml
+++ b/specs/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>io.nuun</groupId>
             <artifactId>kernel-specs</artifactId>
-            <version>1.0.M6-SNAPSHOT</version>
+            <version>${nuun-kernel.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/specs/pom.xml
+++ b/specs/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>io.nuun</groupId>
             <artifactId>kernel-specs</artifactId>
-            <version>${nuun-kernel.version}</version>
+            <version>1.0.M6-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/specs/src/main/java/org/seedstack/seed/Application.java
+++ b/specs/src/main/java/org/seedstack/seed/Application.java
@@ -8,7 +8,6 @@
 package org.seedstack.seed;
 
 import java.io.File;
-import java.io.IOException;
 
 /**
  * This class specifies an interface to the application global object which consists of:
@@ -70,7 +69,7 @@ public interface Application {
     /**
      * Return the application global configuration.
      *
-     * @return the configuration object.
+     * @return the configuration
      */
     org.apache.commons.configuration.Configuration getConfiguration();
 

--- a/specs/src/main/java/org/seedstack/seed/core/spi/configuration/ConfigurationProvider.java
+++ b/specs/src/main/java/org/seedstack/seed/core/spi/configuration/ConfigurationProvider.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.core.spi.configuration;
+
+import io.nuun.kernel.api.annotations.Facet;
+import org.apache.commons.configuration.Configuration;
+
+/**
+ * This interface provides methods to access the application configuration.
+ * <p>
+ * It is exposed by the ApplicationPlugin to other plugins. It cannot be injected.
+ * </p>
+ *
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+@Facet
+public interface ConfigurationProvider {
+    
+    /**
+     * Return the application global configuration.
+     *
+     * @return the configuration object.
+     */
+    Configuration getConfiguration();
+
+    /**
+     * Looks for eventual props configuration for a class.
+     *
+     * @return the configuration map
+     */
+    Configuration getConfiguration(Class<?> clazz);
+}

--- a/testing/src/main/java/org/seedstack/seed/it/internal/ITPlugin.java
+++ b/testing/src/main/java/org/seedstack/seed/it/internal/ITPlugin.java
@@ -7,6 +7,7 @@
  */
 package org.seedstack.seed.it.internal;
 
+import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import com.google.inject.Module;
 import io.nuun.kernel.api.Plugin;
@@ -15,7 +16,7 @@ import io.nuun.kernel.api.plugin.PluginException;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
 import io.nuun.kernel.core.AbstractPlugin;
-import io.nuun.kernel.core.internal.context.InitContextInternal;
+import io.nuun.kernel.core.internal.InitContextInternal;
 import org.kametic.specifications.Specification;
 import org.seedstack.seed.SeedException;
 import org.seedstack.seed.core.internal.application.ApplicationPlugin;
@@ -30,12 +31,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * This plugin automatically enable integration tests to be managed by SEED.
@@ -161,10 +157,8 @@ public class ITPlugin extends AbstractPlugin {
     }
 
     @Override
-    public Collection<Class<? extends Plugin>> dependentPlugins() {
-        Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
-        plugins.add(ApplicationPlugin.class);
-        return plugins;
+    public Collection<Class<?>> dependentPlugins() {
+        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class);
     }
 
     private void deleteRecursively(final File file) throws IOException {

--- a/transaction/src/main/java/org/seedstack/seed/transaction/internal/TransactionPlugin.java
+++ b/transaction/src/main/java/org/seedstack/seed/transaction/internal/TransactionPlugin.java
@@ -9,12 +9,6 @@ package org.seedstack.seed.transaction.internal;
 
 import com.google.common.collect.Lists;
 import com.google.inject.matcher.Matcher;
-import org.seedstack.seed.core.internal.application.ApplicationPlugin;
-import org.seedstack.seed.core.utils.SeedMatchers;
-import org.seedstack.seed.transaction.Transactional;
-import org.seedstack.seed.transaction.spi.TransactionHandler;
-import org.seedstack.seed.transaction.spi.TransactionManager;
-import org.seedstack.seed.transaction.spi.TransactionMetadataResolver;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.PluginException;
 import io.nuun.kernel.api.plugin.context.InitContext;
@@ -22,6 +16,12 @@ import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
 import io.nuun.kernel.core.AbstractPlugin;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang.StringUtils;
+import org.seedstack.seed.core.spi.configuration.ConfigurationProvider;
+import org.seedstack.seed.core.utils.SeedMatchers;
+import org.seedstack.seed.transaction.Transactional;
+import org.seedstack.seed.transaction.spi.TransactionHandler;
+import org.seedstack.seed.transaction.spi.TransactionManager;
+import org.seedstack.seed.transaction.spi.TransactionMetadataResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +32,6 @@ import java.util.Set;
 
 /**
  * This plugin manages transactional matters in SEED code:
- *
  * <ul>
  * <li>detects transaction-enabled methods and add the corresponding interceptor around them,</li>
  * <li>holds a registry of all transaction handlers,</li>
@@ -60,8 +59,7 @@ public class TransactionPlugin extends AbstractPlugin {
     @Override
     @SuppressWarnings("unchecked")
     public InitState init(InitContext initContext) {
-        ApplicationPlugin applicationPlugin = (ApplicationPlugin) initContext.pluginsRequired().iterator().next();
-        Configuration transactionConfiguration = applicationPlugin.getApplication().getConfiguration().subset(TransactionPlugin.TRANSACTION_PLUGIN_CONFIGURATION_PREFIX);
+        Configuration transactionConfiguration = initContext.dependency(ConfigurationProvider.class).getConfiguration().subset(TransactionPlugin.TRANSACTION_PLUGIN_CONFIGURATION_PREFIX);
 
         String transactionManagerClassname = transactionConfiguration.getString("manager");
         if (transactionManagerClassname != null && !transactionManagerClassname.isEmpty()) {
@@ -105,7 +103,7 @@ public class TransactionPlugin extends AbstractPlugin {
 
     @Override
     public Collection<Class<?>> requiredPlugins() {
-        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class);
+        return Lists.<Class<?>>newArrayList(ConfigurationProvider.class);
     }
 
     @Override

--- a/transaction/src/main/java/org/seedstack/seed/transaction/internal/TransactionPlugin.java
+++ b/transaction/src/main/java/org/seedstack/seed/transaction/internal/TransactionPlugin.java
@@ -7,6 +7,7 @@
  */
 package org.seedstack.seed.transaction.internal;
 
+import com.google.common.collect.Lists;
 import com.google.inject.matcher.Matcher;
 import org.seedstack.seed.core.internal.application.ApplicationPlugin;
 import org.seedstack.seed.core.utils.SeedMatchers;
@@ -14,7 +15,6 @@ import org.seedstack.seed.transaction.Transactional;
 import org.seedstack.seed.transaction.spi.TransactionHandler;
 import org.seedstack.seed.transaction.spi.TransactionManager;
 import org.seedstack.seed.transaction.spi.TransactionMetadataResolver;
-import io.nuun.kernel.api.Plugin;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.PluginException;
 import io.nuun.kernel.api.plugin.context.InitContext;
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -105,10 +104,8 @@ public class TransactionPlugin extends AbstractPlugin {
     }
 
     @Override
-    public Collection<Class<? extends Plugin>> requiredPlugins() {
-        Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
-        plugins.add(ApplicationPlugin.class);
-        return plugins;
+    public Collection<Class<?>> requiredPlugins() {
+        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class);
     }
 
     @Override

--- a/transaction/src/test/java/org/seedstack/seed/transaction/internal/TransactionPluginTest.java
+++ b/transaction/src/test/java/org/seedstack/seed/transaction/internal/TransactionPluginTest.java
@@ -25,13 +25,9 @@ import org.seedstack.seed.transaction.spi.TransactionHandlerTestImpl;
 import org.seedstack.seed.transaction.spi.TransactionManager;
 import org.seedstack.seed.transaction.spi.TransactionMetadataResolver;
 import org.seedstack.seed.transaction.spi.TransactionMetadataResolverTestImpl;
+import org.seedstack.seed.core.spi.configuration.ConfigurationProvider;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -163,14 +159,8 @@ public class TransactionPluginTest {
         implementsTransactionMetadataResolverClasses.add(TransactionMetadataResolverTestImpl.class);
         mapImplements.put(TransactionMetadataResolver.class, implementsTransactionMetadataResolverClasses);
         when(initContext.scannedSubTypesByParentClass()).thenReturn(mapImplements);
-        Collection plugins = mock(Collection.class);
-        Iterator iterator = mock(Iterator.class);
-        when(initContext.pluginsRequired()).thenReturn(plugins);
-        when(plugins.iterator()).thenReturn(iterator);
-        when((ApplicationPlugin) iterator.next()).thenReturn(applicationPlugin);
-        Assertions.assertThat(initContext).isNotNull();
-        Assertions.assertThat(applicationPlugin).isNotNull();
-        Assertions.assertThat(configuration).isNotNull();
+        when(initContext.dependency(ConfigurationProvider.class)).thenReturn(applicationPlugin);
+        when(applicationPlugin.getConfiguration()).thenReturn(configuration);
         return initContext;
     }
 

--- a/web/core/src/main/java/org/seedstack/seed/web/internal/WebCorsPlugin.java
+++ b/web/core/src/main/java/org/seedstack/seed/web/internal/WebCorsPlugin.java
@@ -7,7 +7,7 @@
  */
 package org.seedstack.seed.web.internal;
 
-import io.nuun.kernel.api.Plugin;
+import com.google.common.collect.Lists;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.core.AbstractPlugin;
@@ -18,7 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletContext;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -78,10 +77,8 @@ public class WebCorsPlugin extends AbstractPlugin {
     }
 
     @Override
-    public Collection<Class<? extends Plugin>> requiredPlugins() {
-        Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
-        plugins.add(ApplicationPlugin.class);
-        return plugins;
+    public Collection<Class<?>> requiredPlugins() {
+        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class);
     }
 
     @Override

--- a/web/core/src/main/java/org/seedstack/seed/web/internal/WebCorsPlugin.java
+++ b/web/core/src/main/java/org/seedstack/seed/web/internal/WebCorsPlugin.java
@@ -12,7 +12,7 @@ import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.core.AbstractPlugin;
 import org.apache.commons.configuration.Configuration;
-import org.seedstack.seed.core.internal.application.ApplicationPlugin;
+import org.seedstack.seed.core.spi.configuration.ConfigurationProvider;
 import org.seedstack.seed.core.utils.SeedConfigurationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,8 +48,7 @@ public class WebCorsPlugin extends AbstractPlugin {
             return InitState.INITIALIZED;
         }
 
-        ApplicationPlugin applicationPlugin = (ApplicationPlugin) initContext.pluginsRequired().iterator().next();
-        Configuration webConfiguration = applicationPlugin.getApplication().getConfiguration().subset(WebPlugin.WEB_PLUGIN_PREFIX);
+        Configuration webConfiguration = initContext.dependency(ConfigurationProvider.class).getConfiguration().subset(WebPlugin.WEB_PLUGIN_PREFIX);
 
         boolean corsEnabled = webConfiguration.getBoolean("cors.enabled", false);
         Map<String, String> corsParameters = new HashMap<String, String>();
@@ -78,7 +77,7 @@ public class WebCorsPlugin extends AbstractPlugin {
 
     @Override
     public Collection<Class<?>> requiredPlugins() {
-        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class);
+        return Lists.<Class<?>>newArrayList(ConfigurationProvider.class);
     }
 
     @Override

--- a/web/core/src/main/java/org/seedstack/seed/web/internal/WebPlugin.java
+++ b/web/core/src/main/java/org/seedstack/seed/web/internal/WebPlugin.java
@@ -7,9 +7,9 @@
  */
 package org.seedstack.seed.web.internal;
 
+import com.google.common.collect.Lists;
 import com.google.inject.Module;
 import com.google.inject.servlet.ServletModule;
-import io.nuun.kernel.api.Plugin;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
@@ -76,7 +76,7 @@ public class WebPlugin extends AbstractPlugin {
 
         WebDiagnosticCollector webDiagnosticCollector = new WebDiagnosticCollector(servletContext);
         ApplicationPlugin applicationPlugin = null;
-        for (Plugin plugin : initContext.pluginsRequired()) {
+        for (Object plugin : initContext.pluginsRequired()) {
             if (plugin instanceof ApplicationPlugin) {
                 applicationPlugin = (ApplicationPlugin) plugin;
             } else if (plugin instanceof CorePlugin) {
@@ -190,11 +190,8 @@ public class WebPlugin extends AbstractPlugin {
     }
 
     @Override
-    public Collection<Class<? extends Plugin>> requiredPlugins() {
-        Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
-        plugins.add(CorePlugin.class);
-        plugins.add(ApplicationPlugin.class);
-        return plugins;
+    public Collection<Class<?>> requiredPlugins() {
+        return Lists.<Class<?>>newArrayList(CorePlugin.class, ApplicationPlugin.class);
     }
 
     @Override

--- a/web/security/src/main/java/org/seedstack/seed/web/security/internal/WebSecurityProvider.java
+++ b/web/security/src/main/java/org/seedstack/seed/web/security/internal/WebSecurityProvider.java
@@ -48,7 +48,7 @@ public class WebSecurityProvider implements SecurityProvider {
     @Override
     public void init(InitContext initContext) {
         ApplicationPlugin applicationPlugin = null;
-        for (Plugin plugin : initContext.pluginsRequired()) {
+        for (Object plugin : initContext.pluginsRequired()) {
             if (plugin instanceof ApplicationPlugin) {
                 applicationPlugin = ((ApplicationPlugin) plugin);
             }

--- a/web/security/src/main/java/org/seedstack/seed/web/security/internal/WebSecurityProvider.java
+++ b/web/security/src/main/java/org/seedstack/seed/web/security/internal/WebSecurityProvider.java
@@ -9,16 +9,13 @@ package org.seedstack.seed.web.security.internal;
 
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
-import io.nuun.kernel.api.Plugin;
 import io.nuun.kernel.api.plugin.PluginException;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.api.plugin.request.ClasspathScanRequestBuilder;
 import jodd.props.Props;
 import org.apache.shiro.guice.web.ShiroWebModule;
-import org.seedstack.seed.SeedException;
 import org.seedstack.seed.core.internal.application.ApplicationPlugin;
 import org.seedstack.seed.security.internal.SecurityProvider;
-import org.seedstack.seed.web.internal.WebErrorCode;
 import org.seedstack.seed.web.security.SecurityFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,16 +44,7 @@ public class WebSecurityProvider implements SecurityProvider {
     @SuppressWarnings("unchecked")
     @Override
     public void init(InitContext initContext) {
-        ApplicationPlugin applicationPlugin = null;
-        for (Object plugin : initContext.pluginsRequired()) {
-            if (plugin instanceof ApplicationPlugin) {
-                applicationPlugin = ((ApplicationPlugin) plugin);
-            }
-        }
-
-        if (applicationPlugin == null) {
-            throw SeedException.createNew(WebErrorCode.PLUGIN_NOT_FOUND).put("plugin", "application");
-        }
+        ApplicationPlugin applicationPlugin = initContext.dependency(ApplicationPlugin.class);
 
         props = applicationPlugin.getProps();
         applicationId = applicationPlugin.getApplication().getId();

--- a/web/undertow/src/main/java/org/seedstack/seed/undertow/internal/ServerConfigFactory.java
+++ b/web/undertow/src/main/java/org/seedstack/seed/undertow/internal/ServerConfigFactory.java
@@ -8,16 +8,14 @@
 package org.seedstack.seed.undertow.internal;
 
 import org.apache.commons.configuration.Configuration;
-import org.seedstack.seed.crypto.spi.SSLConfiguration;
-
-import javax.net.ssl.SSLContext;
+import org.seedstack.seed.crypto.spi.SSLProvider;
 
 /**
  * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
  */
 public class ServerConfigFactory {
 
-    public ServerConfig create(Configuration configuration, SSLConfiguration SSLConfiguration, SSLContext sslContext) {
+    public ServerConfig create(Configuration configuration, SSLProvider sslProvider) {
         ServerConfig serverConfig = new ServerConfig();
         if (configuration.containsKey("host")) {
             serverConfig.setHost(configuration.getString("host"));
@@ -53,8 +51,8 @@ public class ServerConfigFactory {
             serverConfig.setDirectBuffers(configuration.getBoolean("direct-buffers"));
         }
 
-        serverConfig.setSSLConfiguration(SSLConfiguration);
-        serverConfig.setSslContext(sslContext);
+        serverConfig.setSSLConfiguration(sslProvider.sslConfig());
+        serverConfig.setSslContext(sslProvider.sslContext());
         return serverConfig;
     }
 }

--- a/web/undertow/src/main/java/org/seedstack/seed/undertow/internal/UndertowLauncher.java
+++ b/web/undertow/src/main/java/org/seedstack/seed/undertow/internal/UndertowLauncher.java
@@ -10,7 +10,6 @@ package org.seedstack.seed.undertow.internal;
 import io.nuun.kernel.api.Kernel;
 import io.nuun.kernel.api.Plugin;
 import io.nuun.kernel.core.NuunCore;
-import io.nuun.kernel.core.internal.KernelCore;
 import io.undertow.Undertow;
 import io.undertow.servlet.api.DeploymentManager;
 import io.undertow.servlet.spec.ServletContextImpl;
@@ -21,11 +20,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletContext;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.Map;
 
 /**
  * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
@@ -63,16 +60,8 @@ public class UndertowLauncher implements SeedLauncher {
 
     private UndertowPlugin getUndertowPlugin(Kernel kernel) {
         UndertowPlugin undertowPlugin = null;
-        Map<String, Plugin> pluginMap;
-        try {
-            Field field = KernelCore.class.getDeclaredField("plugins");
-            field.setAccessible(true);
-            //noinspection unchecked
-            pluginMap = (Map<String, Plugin>) field.get(kernel);
-        } catch (Exception e) {
-            throw SeedException.wrap(e, UndertowErrorCode.UNEXPECTED_EXCEPTION);
-        }
-        Plugin plugin = pluginMap.get("undertow-plugin");
+
+        Plugin plugin = kernel.plugins().get(UndertowPlugin.NAME);
         if (plugin instanceof UndertowPlugin) {
             undertowPlugin = (UndertowPlugin) plugin;
         }

--- a/web/undertow/src/main/java/org/seedstack/seed/undertow/internal/UndertowPlugin.java
+++ b/web/undertow/src/main/java/org/seedstack/seed/undertow/internal/UndertowPlugin.java
@@ -18,11 +18,7 @@ import org.seedstack.seed.crypto.spi.SSLProvider;
 import java.util.Collection;
 
 /**
- * The Undertow plugin is responsible to start and stop the Undertow HTTP server.
- * <p>
- * It requires that a {@link io.undertow.servlet.api.DeploymentManager} being passed
- * using the setDeploymentManager() method. Otherwise the server won't be started.
- * </p>
+ * The Undertow plugin is responsible to retrieve the undertow configuration.
  *
  * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
  */
@@ -39,10 +35,9 @@ public class UndertowPlugin extends AbstractPlugin {
 
     @Override
     public InitState init(InitContext initContext) {
-        Configuration configuration = initContext.dependency(ConfigurationProvider.class).getConfiguration();
-        serverConfig = new ServerConfigFactory()
-                .create(configuration.subset(CONFIGURATION_PREFIX), initContext.dependency(SSLProvider.class));
-
+        Configuration serverConfig = initContext.dependency(ConfigurationProvider.class)
+                .getConfiguration().subset(CONFIGURATION_PREFIX);
+        this.serverConfig = new ServerConfigFactory().create(serverConfig, initContext.dependency(SSLProvider.class));
         return InitState.INITIALIZED;
     }
 

--- a/web/undertow/src/main/java/org/seedstack/seed/undertow/internal/UndertowPlugin.java
+++ b/web/undertow/src/main/java/org/seedstack/seed/undertow/internal/UndertowPlugin.java
@@ -7,7 +7,7 @@
  */
 package org.seedstack.seed.undertow.internal;
 
-import io.nuun.kernel.api.Plugin;
+import com.google.common.collect.Lists;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.Context;
 import io.nuun.kernel.api.plugin.context.InitContext;
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
-import java.util.ArrayList;
 import java.util.Collection;
 
 /**
@@ -40,13 +39,14 @@ public class UndertowPlugin extends AbstractPlugin {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UndertowPlugin.class);
     private static final String UNDERTOW_PLUGIN_PREFIX = "org.seedstack.seed.server";
+    public static final String NAME = "undertow-plugin";
     private DeploymentManager deploymentManager;
     private Undertow server;
     private ServerConfig serverConfig;
 
     @Override
     public String name() {
-        return "undertow-plugin";
+        return NAME;
     }
 
     @Override
@@ -54,7 +54,7 @@ public class UndertowPlugin extends AbstractPlugin {
         Configuration configuration = null;
         SSLConfiguration SSLConfiguration = null;
         SSLContext sslContext = null;
-        for (Plugin plugin : initContext.pluginsRequired()) {
+        for (Object plugin : initContext.pluginsRequired()) {
             if (plugin instanceof ApplicationPlugin) {
                 configuration = ((ApplicationPlugin) plugin).getApplication().getConfiguration();
             } else if (SSLProvider.class.isAssignableFrom(plugin.getClass())) {
@@ -105,11 +105,8 @@ public class UndertowPlugin extends AbstractPlugin {
     }
 
     @Override
-    public Collection<Class<? extends Plugin>> requiredPlugins() {
-        Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
-        plugins.add(ApplicationPlugin.class);
-        plugins.add(CryptoPlugin.class);
-        return plugins;
+    public Collection<Class<?>> requiredPlugins() {
+        return Lists.<Class<?>>newArrayList(ApplicationPlugin.class, CryptoPlugin.class);
     }
 
 }


### PR DESCRIPTION
Change the way plugins access the configuration using nuun facet (plugin interface):

*Before:*
```
restConfiguration = null;
webPlugin = null;
for (Plugin plugin : initContext.pluginsRequired()) {
    if (plugin instanceof ApplicationPlugin) {
        restConfiguration = ((ApplicationPlugin) plugin).getApplication().getConfiguration().subset(RestPlugin.REST_PLUGIN_CONFIGURATION_PREFIX);
    } else if (plugin instanceof WebPlugin) {
        webPlugin = (WebPlugin) plugin;
    }
}
```
*After:*
```
restConfiguration = initContext.dependency(ConfigurationProvider.class) // access facet
    .getConfiguration().subset(RestPlugin.REST_PLUGIN_CONFIGURATION_PREFIX);

webPlugin = initContext.dependency(WebPlugin.class); // access plugin
```

The dependency declaration can also be shortcut:

*Before:*
```
@Override
public Collection<Class<? extends Plugin>> requiredPlugins() {
        Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
        plugins.add(ApplicationPlugin.class);
        return plugins;
}
```
*After:*
```
@Override
public Collection<Class<?>> requiredPlugins() {
        return Lists.<Class<?>>newArrayList(ConfigurationProvider.class);
}
```