### PR TITLE
Anti CSRF/XSRF service and security filter

### DIFF
--- a/web/security/src/it/java/org/seedstack/seed/web/security/XsrfIT.java
+++ b/web/security/src/it/java/org/seedstack/seed/web/security/XsrfIT.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.web.security;
+
+import com.jayway.restassured.response.Response;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.seedstack.seed.it.AbstractSeedWebIT;
+
+import java.net.URL;
+
+import static com.jayway.restassured.RestAssured.expect;
+import static com.jayway.restassured.RestAssured.given;
+
+public class XsrfIT extends AbstractSeedWebIT {
+    public static final String XSRF_COOKIE_NAME = "XSRF-TOKEN";
+    public static final String XSRF_HEADER_NAME = "X-XSRF-TOKEN";
+    public static final String SESSION_COOKIE_NAME = "JSESSIONID";
+
+    @ArquillianResource
+    private URL baseURL;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class).addAsResource("META-INF/configuration/org.seedstack.seed.web.security.props").setWebXML("WEB-INF/web.xml");
+    }
+
+    @Test
+    @RunAsClient
+    public void request_without_session_should_succeed() throws Exception {
+        expect()
+                .statusCode(200)
+                .when()
+                .get(baseURL.toString() + "xsrf-protected-without-session");
+    }
+
+    @Test
+    @RunAsClient
+    public void request_without_token_should_fail() throws Exception {
+        String sessionId = initiateSession(baseURL).getCookie("JSESSIONID");
+        given()
+                .cookie(SESSION_COOKIE_NAME, sessionId)
+                .expect()
+                .statusCode(403)
+                .when()
+                .get(baseURL.toString() + "xsrf-protected-with-session");
+    }
+
+    @Test
+    @RunAsClient
+    public void request_with_cookie_only_should_fail() throws Exception {
+        Response response = initiateSession(baseURL);
+        String sessionId = response.getCookie(SESSION_COOKIE_NAME);
+        String token = response.getCookie(XSRF_COOKIE_NAME);
+        given()
+                .cookie(SESSION_COOKIE_NAME, sessionId)
+                .and()
+                .cookie(XSRF_COOKIE_NAME, token)
+                .expect()
+                .statusCode(403)
+                .when()
+                .get(baseURL.toString() + "xsrf-protected-with-session");
+    }
+
+    @Test
+    @RunAsClient
+    public void request_with_header_only_should_fail() throws Exception {
+        Response response = initiateSession(baseURL);
+        String sessionId = response.getCookie(SESSION_COOKIE_NAME);
+        String token = response.getCookie(XSRF_COOKIE_NAME);
+        given()
+                .cookie(SESSION_COOKIE_NAME, sessionId)
+                .and()
+                .header(XSRF_HEADER_NAME, token)
+                .expect()
+                .statusCode(403)
+                .when()
+                .get(baseURL.toString() + "xsrf-protected-with-session");
+    }
+
+    @Test
+    @RunAsClient
+    public void request_with_cookie_and_header_should_succeed() throws Exception {
+        Response response = initiateSession(baseURL);
+        String sessionId = response.getCookie(SESSION_COOKIE_NAME);
+        String token = response.getCookie(XSRF_COOKIE_NAME);
+        given()
+                .cookie(SESSION_COOKIE_NAME, sessionId)
+                .and()
+                .cookie(XSRF_COOKIE_NAME, token)
+                .and()
+                .header(XSRF_HEADER_NAME, token)
+                .expect()
+                .statusCode(200)
+                .when()
+                .get(baseURL.toString() + "xsrf-protected-with-session");
+    }
+
+    private Response initiateSession(URL baseURL) {
+        return given().auth().basic("Obiwan", "yodarulez").expect().statusCode(200).when().get(baseURL.toString() + "xsrf-protected-with-session");
+    }
+}

--- a/web/security/src/it/java/org/seedstack/seed/web/security/fixtures/TeapotFilter.java
+++ b/web/security/src/it/java/org/seedstack/seed/web/security/fixtures/TeapotFilter.java
@@ -5,13 +5,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.seed.web.security;
+package org.seedstack.seed.web.security.fixtures;
 
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.shiro.web.filter.PathMatchingFilter;
+import org.seedstack.seed.web.security.SecurityFilter;
 
 /**
  * Test filters that sends response with 418 code (I'm a teapot)

--- a/web/security/src/it/java/org/seedstack/seed/web/security/fixtures/XsrfProtectedServlet.java
+++ b/web/security/src/it/java/org/seedstack/seed/web/security/fixtures/XsrfProtectedServlet.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.web.security.fixtures;
+
+import org.seedstack.seed.web.WebServlet;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebServlet({"/xsrf-protected-without-session", "/xsrf-protected-with-session"})
+public class XsrfProtectedServlet extends HttpServlet {
+
+    public static final String WELCOME = "WELCOME";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setStatus(200);
+        resp.setContentLength(WELCOME.length());
+        resp.setContentType("text/plain");
+        resp.getWriter().write(WELCOME);
+    }
+}

--- a/web/security/src/it/resources/META-INF/configuration/org.seedstack.seed.web.security.props
+++ b/web/security/src/it/resources/META-INF/configuration/org.seedstack.seed.web.security.props
@@ -30,4 +30,6 @@ padawan = academy:learn
 /jediAcademy.html = authcBasic, perms[academy:learn]
 /logout = logout
 /teapot = teapot
+/xsrf-protected-without-session = xsrf
+/xsrf-protected-with-session = authcBasic, xsrf
 /** = authcBasic

--- a/web/security/src/main/java/org/seedstack/seed/web/security/internal/AntiXsrfFilter.java
+++ b/web/security/src/main/java/org/seedstack/seed/web/security/internal/AntiXsrfFilter.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.web.security.internal;
+
+import org.apache.shiro.web.servlet.AdviceFilter;
+import org.seedstack.seed.SeedException;
+import org.seedstack.seed.web.security.spi.AntiXsrfService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+class AntiXsrfFilter extends AdviceFilter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AntiXsrfFilter.class);
+
+    @Inject
+    AntiXsrfService AntiXsrfService;
+
+    @Override
+    protected boolean preHandle(ServletRequest request, ServletResponse response) throws Exception {
+        try {
+            AntiXsrfService.applyXsrfProtection((HttpServletRequest) request, (HttpServletResponse) response);
+            return true;
+        } catch (SeedException e) {
+            switch ((WebSecurityErrorCodes) e.getErrorCode()) {
+                case MISSING_XSRF_HEADER:
+                    ((HttpServletResponse) response).sendError(HttpServletResponse.SC_FORBIDDEN, "Missing XSRF protection token in the request");
+                    return false;
+                case MISSING_XSRF_COOKIE:
+                    ((HttpServletResponse) response).sendError(HttpServletResponse.SC_FORBIDDEN, "Missing XSRF protection token cookie");
+                    return false;
+                case INVALID_XSRF_TOKEN:
+                    ((HttpServletResponse) response).sendError(HttpServletResponse.SC_FORBIDDEN, "Request token does not match session token");
+                    return false;
+                default:
+                    LOGGER.error("An error occurred when applying XSRF protection", e);
+                    return false;
+            }
+        }
+    }
+
+    protected void postHandle(ServletRequest request, ServletResponse response) throws Exception {
+        AntiXsrfService.cleanXsrfProtection((HttpServletRequest) request, (HttpServletResponse) response);
+    }
+}

--- a/web/security/src/main/java/org/seedstack/seed/web/security/internal/StatelessAntiXsrfService.java
+++ b/web/security/src/main/java/org/seedstack/seed/web/security/internal/StatelessAntiXsrfService.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.web.security.internal;
+
+import org.seedstack.seed.Configuration;
+import org.seedstack.seed.SeedException;
+import org.seedstack.seed.web.security.spi.AntiXsrfService;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.security.SecureRandom;
+
+class StatelessAntiXsrfService implements AntiXsrfService {
+    static final String CONFIG_PREFIX = "org.seedstack.seed.security.xsrf";
+
+    final static char[] CHARSET = new char[]{'a', 'b', 'c', 'd', 'e',
+            'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
+            's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4',
+            '5', '6', '7', '8', '9'};
+
+    @Configuration(value = CONFIG_PREFIX + ".cookie-name", defaultValue = "XSRF-TOKEN")
+    private String cookieName;
+    @Configuration(value = CONFIG_PREFIX + ".header-name", defaultValue = "X-XSRF-TOKEN")
+    private String headerName;
+    @Configuration(value = CONFIG_PREFIX + ".token-length", defaultValue = "20")
+    private int tokenLength;
+    @Configuration(value = CONFIG_PREFIX + ".token-algorithm", defaultValue = "SHA1PRNG")
+    private String tokenAlgorithm;
+
+    @Override
+    public void applyXsrfProtection(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        HttpSession session = httpServletRequest.getSession(false);
+
+        // Only apply XSRF protection when there is a session
+        if (session != null) {
+            // If session is new, generate a token and put it in a cookie
+            if (session.isNew()) {
+                Cookie cookie = new Cookie(cookieName, generateToken());
+                cookie.setHttpOnly(false);
+                cookie.setPath("/");
+                cookie.setMaxAge(-1);
+                httpServletResponse.addCookie(cookie);
+            }
+            // Else, check if the request and cookie tokens match
+            else {
+                String cookieToken = extractCookieToken(httpServletRequest);
+                String requestToken = httpServletRequest.getHeader(headerName);
+
+                if (requestToken == null) {
+                    throw SeedException.createNew(WebSecurityErrorCodes.MISSING_XSRF_HEADER);
+                }
+
+                if (cookieToken == null) {
+                    throw SeedException.createNew(WebSecurityErrorCodes.MISSING_XSRF_COOKIE);
+                }
+
+                // Check for multiple headers (keep only the first one)
+                int commaIndex = requestToken.indexOf(',');
+                if (commaIndex != -1) {
+                    requestToken = requestToken.substring(0, commaIndex).trim();
+                }
+
+                // Check if tokens match
+                if (!cookieToken.equals(requestToken)) {
+                    throw SeedException.createNew(WebSecurityErrorCodes.INVALID_XSRF_TOKEN);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void cleanXsrfProtection(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
+        HttpSession session = httpServletRequest.getSession(false);
+
+        // Delete an eventual existing token if no session
+        if (session == null) {
+            Cookie cookie = new Cookie(cookieName, "deleteMe");
+            cookie.setHttpOnly(false);
+            cookie.setPath("/");
+            cookie.setMaxAge(0);
+            httpServletResponse.addCookie(cookie);
+        }
+    }
+
+    private String extractCookieToken(HttpServletRequest httpServletRequest) {
+        for (Cookie cookie : httpServletRequest.getCookies()) {
+            if (cookieName.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+
+        return null;
+    }
+
+    private String generateToken() {
+        try {
+            SecureRandom secureRandom = SecureRandom.getInstance(tokenAlgorithm);
+            StringBuilder sb = new StringBuilder();
+
+            for (int i = 1; i < tokenLength + 1; i++) {
+                sb.append(CHARSET[secureRandom.nextInt(CHARSET.length)]);
+
+                if ((i % 4) == 0 && i != 0 && i < tokenLength) {
+                    sb.append('-');
+                }
+            }
+
+            return sb.toString();
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("Unable to generate the random token - %s", e.getLocalizedMessage()), e);
+        }
+    }
+}

--- a/web/security/src/main/java/org/seedstack/seed/web/security/internal/WebSecurityErrorCodes.java
+++ b/web/security/src/main/java/org/seedstack/seed/web/security/internal/WebSecurityErrorCodes.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.web.security.internal;
+
+import org.seedstack.seed.ErrorCode;
+
+enum WebSecurityErrorCodes implements ErrorCode {
+    UNABLE_TO_APPLY_XSRF_PROTECTION,
+    MISSING_XSRF_COOKIE,
+    MISSING_XSRF_HEADER,
+    INVALID_XSRF_TOKEN
+}

--- a/web/security/src/main/java/org/seedstack/seed/web/security/internal/X509CertificateFilter.java
+++ b/web/security/src/main/java/org/seedstack/seed/web/security/internal/X509CertificateFilter.java
@@ -13,7 +13,6 @@ import org.apache.shiro.subject.Subject;
 import org.apache.shiro.web.filter.authc.AuthenticatingFilter;
 import org.seedstack.seed.security.X509CertificateToken;
 import org.seedstack.seed.security.internal.realms.AuthenticationTokenWrapper;
-import org.seedstack.seed.web.security.SecurityFilter;
 
 import javax.servlet.Filter;
 import javax.servlet.ServletRequest;
@@ -24,11 +23,10 @@ import java.security.cert.X509Certificate;
 
 /**
  * A security filter that extracts the certificate from the request for later use
- * 
+ *
  * @author yves.dautremay@mpsa.com
  */
-@SecurityFilter("cert")
-public class X509CertificateFilter extends AuthenticatingFilter implements Filter {
+class X509CertificateFilter extends AuthenticatingFilter implements Filter {
 
     private static final String OPTIONAL = "optional";
 

--- a/web/specs/src/main/java/org/seedstack/seed/web/security/spi/AntiXsrfService.java
+++ b/web/specs/src/main/java/org/seedstack/seed/web/security/spi/AntiXsrfService.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.web.security.spi;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * This service provides Cross-Site-Request-Forgery (CSRF or XSRF) protection to HTTP requests.
+ *
+ * @author adrien.lauer@mpsa.com
+ */
+public interface AntiXsrfService {
+    void applyXsrfProtection(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse);
+
+    void cleanXsrfProtection(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse);
+}


### PR DESCRIPTION
Fixes #159 

This is a stateless XSRF protection implementation, matching a cookie-based and HTTP header-based token. This is implemented as a service `AntiXsrfService` which can be used to apply the logic anywhere. This service is used in a Shiro security filter named `xsrf` that can be applied on any URL pattern.

Also fixes the missing bindings for security filters not inheriting PathMatchingFilter.