### PR TITLE
Add support for Jersey2

### DIFF
--- a/crypto/src/test/java/org/seedstack/seed/crypto/internal/CryptoPluginTest.java
+++ b/crypto/src/test/java/org/seedstack/seed/crypto/internal/CryptoPluginTest.java
@@ -34,42 +34,27 @@ import java.util.Map;
  */
 public class CryptoPluginTest {
 
-
-
-    /**
-     * Test method for {@link org.seedstack.seed.crypto.internal.CryptoPlugin#name()}.
-     */
     @Test
     public void testName() {
         Assertions.assertThat(new CryptoPlugin().name()).isEqualTo("seed-crypto-plugin");
     }
 
-    /**
-     * Test method for {@link org.seedstack.seed.crypto.internal.CryptoPlugin#nativeUnitModule()}.
-     */
     @Test
     public void testNativeUnitModule(@SuppressWarnings("unused") @Mocked final CryptoModule module) {
-
         final Map<Key<EncryptionService>, EncryptionService> encryptionServices = new HashMap<Key<EncryptionService>, EncryptionService>();
         final Map<String, KeyStore> keyStores = new HashMap<String, KeyStore>();
+        final CryptoPlugin underTest = new CryptoPlugin();
+        Deencapsulation.setField(underTest, "encryptionServices", encryptionServices);
+        Deencapsulation.setField(underTest, "keyStores", keyStores);
 
-        final CryptoPlugin plugin = new CryptoPlugin();
+        underTest.nativeUnitModule();
 
-        Deencapsulation.setField(plugin, "encryptionServices", encryptionServices);
-        Deencapsulation.setField(plugin, "keyStores", keyStores);
-
-        plugin.nativeUnitModule();
-        new Verifications() {
-            {
-                new CryptoModule(encryptionServices, keyStores);
-                times = 1;
-            }
-        };
+        new Verifications() {{
+            new CryptoModule(encryptionServices, keyStores);
+            times = 1;
+        }};
     }
 
-    /**
-     * Test method for {@link org.seedstack.seed.crypto.internal.CryptoPlugin#requiredPlugins()}.
-     */
     @Test
     public void testRequiredPlugins() {
         CryptoPlugin plugin = new CryptoPlugin();

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,8 @@
                             <licenseMerge>BSD|The BSD License</licenseMerge>
                             <licenseMerge>CDDL 1.1|CDDL or GPLv2 with exceptions</licenseMerge>
                             <licenseMerge>CDDL 1.1|Common Development and Distribution License</licenseMerge>
+                            <licenseMerge>CDDL 1.1|CDDL + GPLv2 with classpath exception</licenseMerge>
+                            <licenseMerge>CDDL 1.1|CDDL+GPL License</licenseMerge>
                             <licenseMerge>EPL 1.0|Eclipse Public License 1.0</licenseMerge>
                             <licenseMerge>EPL 1.0|Eclipse Public License v1.0</licenseMerge>
                             <licenseMerge>LGPL 3.0|GNU Lesser Public License</licenseMerge>

--- a/rest/core/pom.xml
+++ b/rest/core/pom.xml
@@ -40,6 +40,8 @@
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+
+        <!-- PROVIDED -->
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>
@@ -53,6 +55,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- TESTS -->
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <version>${jmockit.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>

--- a/rest/core/src/main/java/org/seedstack/seed/rest/internal/RestPlugin.java
+++ b/rest/core/src/main/java/org/seedstack/seed/rest/internal/RestPlugin.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.internal;
+
+import io.nuun.kernel.api.plugin.InitState;
+import io.nuun.kernel.api.plugin.context.InitContext;
+import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
+import io.nuun.kernel.core.AbstractPlugin;
+import org.kametic.specifications.Specification;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class RestPlugin extends AbstractPlugin {
+
+    public static final Specification<Class<?>> resourcesSpecification = new JaxRsResourceSpecification();
+    public static final Specification<Class<?>> providersSpecification = new JaxRsProviderSpecification();
+
+    private Collection<Class<?>> resources;
+    private Collection<Class<?>> providers;
+
+    @Override
+    public String name() {
+        return "seed-rest";
+    }
+
+    @Override
+    public Collection<ClasspathScanRequest> classpathScanRequests() {
+        return classpathScanRequestBuilder()
+                .specification(providersSpecification)
+                .specification(resourcesSpecification)
+                .build();
+    }
+
+    @Override
+    public InitState init(InitContext initContext) {
+        Map<Specification, Collection<Class<?>>> scannedClasses = initContext.scannedTypesBySpecification();
+        resources = scannedClasses.get(RestPlugin.resourcesSpecification);
+        providers = scannedClasses.get(RestPlugin.providersSpecification);
+        return InitState.INITIALIZED;
+    }
+}

--- a/rest/core/src/main/resources/services/io.nuun.kernel.api.Plugin
+++ b/rest/core/src/main/resources/services/io.nuun.kernel.api.Plugin
@@ -1,0 +1,1 @@
+org.seedstack.seed.rest.internal.RestPlugin

--- a/rest/core/src/test/java/org/seedstack/seed/rest/internal/RestPluginTest.java
+++ b/rest/core/src/test/java/org/seedstack/seed/rest/internal/RestPluginTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.internal;
+
+import com.google.common.collect.Lists;
+import io.nuun.kernel.api.plugin.InitState;
+import io.nuun.kernel.api.plugin.context.InitContext;
+import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
+import mockit.Deencapsulation;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+import org.javatuples.Pair;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kametic.specifications.Specification;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.ext.Provider;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.seedstack.seed.rest.internal.RestPlugin.providersSpecification;
+import static org.seedstack.seed.rest.internal.RestPlugin.resourcesSpecification;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+@RunWith(JMockit.class)
+public class RestPluginTest {
+
+    private RestPlugin underTest = new RestPlugin();
+    @Mocked
+    private InitContext initContext;
+
+    @Test
+    public void testName() throws Exception {
+        assertThat(underTest.name()).isEqualTo("seed-rest");
+    }
+
+    @Test
+    public void testRequestScanForJaxRsClasses() throws Exception {
+        assertScanSpecification(providersSpecification);
+        assertScanSpecification(RestPlugin.resourcesSpecification);
+    }
+
+    private void assertScanSpecification(Specification<Class<?>> specification) {
+        boolean scanSpecification = false;
+        for (ClasspathScanRequest classpathScanRequest : underTest.classpathScanRequests()) {
+            if (classpathScanRequest.specification == specification) {
+                scanSpecification = true;
+                break;
+            }
+        }
+        assertThat(scanSpecification).isTrue();
+    }
+
+    @Test
+    public void testInitIsInitialized() throws Exception {
+        InitState init = underTest.init(initContext);
+        assertThat(init).isEqualTo(InitState.INITIALIZED);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testInitGetJaxRsClasses() throws Exception {
+        givenSpecifications(
+                new Pair(resourcesSpecification, MyResource.class),
+                new Pair(providersSpecification, MyProvider.class)
+        );
+
+        underTest.init(initContext);
+
+        Collection<Class<?>> actualResources = Deencapsulation.getField(underTest, "resources");
+        assertThat(actualResources).containsOnly(MyResource.class);
+        Collection<Class<?>> actualProviders = Deencapsulation.getField(underTest, "providers");
+        assertThat(actualProviders).containsOnly(MyProvider.class);
+    }
+
+    @Path("/")
+    class MyResource {
+    }
+    @Provider
+    class MyProvider {
+    }
+
+    private void givenSpecifications(Pair<Specification<Class<?>>, Class<?>>... specEntries) {
+        final Map<Specification, Collection<Class<?>>> specsMap = new HashMap<Specification, Collection<Class<?>>>();
+        for (Pair<Specification<Class<?>>, Class<?>> specEntry : specEntries) {
+            specsMap.put(specEntry.getValue0(), Lists.<Class<?>>newArrayList(specEntry.getValue1()));
+        }
+        new Expectations() {{
+            initContext.scannedTypesBySpecification();
+            result = specsMap;
+        }};
+    }
+
+    @Test
+    public void testNativeUnitModule() throws Exception {
+        Object module = underTest.nativeUnitModule();
+    }
+}

--- a/rest/jersey1/src/it/java/org/seedstack/seed/rest/fixtures/RestTestPlugin.java
+++ b/rest/jersey1/src/it/java/org/seedstack/seed/rest/fixtures/RestTestPlugin.java
@@ -12,7 +12,7 @@ import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.core.AbstractPlugin;
 import org.seedstack.seed.core.spi.configuration.ConfigurationProvider;
-import org.seedstack.seed.rest.internal.RestPlugin;
+import org.seedstack.seed.rest.internal.Jersey1Plugin;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Variant;
@@ -26,11 +26,11 @@ public class RestTestPlugin extends AbstractPlugin {
 
     @Override
     public InitState init(InitContext initContext) {
-        RestPlugin restPlugin = initContext.dependency(RestPlugin.class);
+        Jersey1Plugin jersey1Plugin = initContext.dependency(Jersey1Plugin.class);
         ConfigurationProvider configurationProvider = initContext.dependency(ConfigurationProvider.class);
 
         if (!configurationProvider.getConfiguration().getBoolean("disable-text-home", false)) {
-            restPlugin.registerRootResource(new Variant(MediaType.TEXT_PLAIN_TYPE, null, null), TextRootResource.class);
+            jersey1Plugin.registerRootResource(new Variant(MediaType.TEXT_PLAIN_TYPE, null, null), TextRootResource.class);
         }
 
         return InitState.INITIALIZED;
@@ -38,6 +38,6 @@ public class RestTestPlugin extends AbstractPlugin {
 
     @Override
     public Collection<Class<?>> requiredPlugins() {
-        return Lists.<Class<?>>newArrayList(RestPlugin.class, ConfigurationProvider.class);
+        return Lists.<Class<?>>newArrayList(Jersey1Plugin.class, ConfigurationProvider.class);
     }
 }

--- a/rest/jersey1/src/main/java/org/seedstack/seed/rest/internal/RestPlugin.java
+++ b/rest/jersey1/src/main/java/org/seedstack/seed/rest/internal/RestPlugin.java
@@ -41,12 +41,7 @@ import javax.servlet.ServletContext;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Variant;
 import java.lang.annotation.Annotation;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 
 /**
  * This plugin enables JAX-RS usage in SEED applications. The JAX-RS implementation is Jersey.

--- a/rest/jersey1/src/main/resources/META-INF/services/io.nuun.kernel.api.Plugin
+++ b/rest/jersey1/src/main/resources/META-INF/services/io.nuun.kernel.api.Plugin
@@ -1,1 +1,1 @@
-org.seedstack.seed.rest.internal.RestPlugin
+org.seedstack.seed.rest.internal.Jersey1Plugin

--- a/rest/jersey2/pom.xml
+++ b/rest/jersey2/pom.xml
@@ -1,0 +1,106 @@
+<!--
+
+    Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.seedstack.seed</groupId>
+        <artifactId>seed-rest</artifactId>
+        <version>2.1.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>seed-rest-jersey2</artifactId>
+
+    <properties>
+        <jersey2.version>2.22.1</jersey2.version>
+        <compatibility.skip>true</compatibility.skip>
+        <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.seedstack.seed</groupId>
+            <artifactId>seed-rest-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <version>2.22.1</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>${javax.servlet-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.seedstack.seed</groupId>
+            <artifactId>seed-web-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>guice-bridge</artifactId>
+            <version>2.4.0-b34</version>
+        </dependency>
+
+        <!-- TESTS -->
+        <dependency>
+            <groupId>org.seedstack.seed</groupId>
+            <artifactId>seed-testing</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seedstack.seed</groupId>
+            <artifactId>seed-web-undertow</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <version>${jmockit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.seedstack.poms</groupId>
+            <artifactId>arquillian-composite</artifactId>
+            <version>${poms.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.restassured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>${rest-assured.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>${jsonassert.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/rest/jersey2/src/it/java/org/seedstack/seed/rest/jersey2/Demo.java
+++ b/rest/jersey2/src/it/java/org/seedstack/seed/rest/jersey2/Demo.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.jersey2;
+
+import org.seedstack.seed.core.SeedMain;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class Demo {
+
+    public static void main(String[] args) throws Exception {
+        SeedMain.getLauncher().launch(args);
+    }
+}

--- a/rest/jersey2/src/it/java/org/seedstack/seed/rest/jersey2/GreetingResource.java
+++ b/rest/jersey2/src/it/java/org/seedstack/seed/rest/jersey2/GreetingResource.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.jersey2;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+@Path("/hello")
+public class GreetingResource {
+
+    @GET
+    @Path("/{name}")
+    public String sayHello(@PathParam("name") String name) {
+        return "hello " + name;
+    }
+
+    @GET
+    public String sayHelloWorld() {
+        return sayHello("world");
+    }
+}

--- a/rest/jersey2/src/it/java/org/seedstack/seed/rest/jersey2/HealthCheckServlet.java
+++ b/rest/jersey2/src/it/java/org/seedstack/seed/rest/jersey2/HealthCheckServlet.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.jersey2;
+
+import org.seedstack.seed.web.WebServlet;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+@WebServlet(value = "/health", name = "health-check")
+public class HealthCheckServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().print("OK");
+    }
+}

--- a/rest/jersey2/src/it/java/org/seedstack/seed/rest/jersey2/Jersey2IT.java
+++ b/rest/jersey2/src/it/java/org/seedstack/seed/rest/jersey2/Jersey2IT.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.jersey2;
+
+import com.jayway.restassured.response.Response;
+import org.assertj.core.api.Assertions;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.json.JSONException;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.seedstack.seed.it.AbstractSeedWebIT;
+
+import java.net.URL;
+
+import static com.jayway.restassured.RestAssured.expect;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class Jersey2IT extends AbstractSeedWebIT {
+
+    @ArquillianResource
+    private URL baseURL;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class).setWebXML("WEB-INF/web.xml");
+    }
+
+    @RunAsClient
+    @Test
+    @Ignore("Resources not scanned by Arquillian")
+    public void test_greetings() throws JSONException {
+        Response response = expect().statusCode(200).given().get(baseURL.toString() + "hello/world");
+        Assertions.assertThat(response.asString()).isEqualTo("hello world");
+    }
+}

--- a/rest/jersey2/src/it/java/org/seedstack/seed/rest/jersey2/SeedApplication.java
+++ b/rest/jersey2/src/it/java/org/seedstack/seed/rest/jersey2/SeedApplication.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.jersey2;
+
+import org.glassfish.jersey.server.ResourceConfig;
+
+import javax.ws.rs.ApplicationPath;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+@ApplicationPath("/")
+public class SeedApplication extends ResourceConfig {
+
+    public SeedApplication() {
+       packages("org.seedstack.seed");
+    }
+}

--- a/rest/jersey2/src/it/resources/WEB-INF/web.xml
+++ b/rest/jersey2/src/it/resources/WEB-INF/web.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<!--<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">-->
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         id="WebApp_ID" version="3.0">
+    <filter>
+        <filter-name>guiceFilter</filter-name>
+        <filter-class>com.google.inject.servlet.GuiceFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>guiceFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <listener>
+        <listener-class>org.seedstack.seed.web.listener.SeedServletContextListener</listener-class>
+    </listener>
+</web-app>
+
+<!--<web-app version="3.1" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_1.xsd">
+
+</web-app>-->

--- a/rest/jersey2/src/it/resources/logback-test.xml
+++ b/rest/jersey2/src/it/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/rest/jersey2/src/main/java/org/seedstack/seed/rest/jersey2/internal/GuiceComponentProvider.java
+++ b/rest/jersey2/src/main/java/org/seedstack/seed/rest/jersey2/internal/GuiceComponentProvider.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.jersey2.internal;
+
+import com.google.inject.Injector;
+import org.glassfish.hk2.api.DynamicConfiguration;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.utilities.binding.ServiceBindingBuilder;
+import org.glassfish.jersey.internal.inject.Injections;
+import org.glassfish.jersey.server.spi.ComponentProvider;
+import org.jvnet.hk2.guice.bridge.api.GuiceBridge;
+import org.jvnet.hk2.guice.bridge.api.GuiceIntoHK2Bridge;
+import org.seedstack.seed.SeedException;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.Path;
+import javax.ws.rs.ext.Provider;
+import java.util.Set;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+@javax.ws.rs.ext.Provider
+public class GuiceComponentProvider implements ComponentProvider {
+
+    private ServiceLocator serviceLocator;
+    private Injector injector;
+
+    @Override
+    public void initialize(ServiceLocator locator) {
+        prepareGuiceHK2Bridge(locator);
+    }
+
+    private void prepareGuiceHK2Bridge(ServiceLocator locator) {
+        setServiceLocatorAndInjector(locator);
+
+        GuiceBridge.getGuiceBridge().initializeGuiceBridge(serviceLocator);
+        GuiceIntoHK2Bridge guiceBridge = locator.getService(GuiceIntoHK2Bridge.class);
+        guiceBridge.bridgeGuiceInjector(injector);
+    }
+
+    private void setServiceLocatorAndInjector(ServiceLocator locator) {
+        this.serviceLocator = locator;
+
+        injector = (Injector) getServletContext().getAttribute(Injector.class.getName());
+        if (injector == null) {
+            throw SeedException.createNew(Jersey2ErrorCodes.MISSING_INJECTOR);
+        }
+    }
+
+    private ServletContext getServletContext() {
+        ServletContext servletContext = serviceLocator.getService(ServletContext.class);
+        if (servletContext == null) {
+            throw SeedException.createNew(Jersey2ErrorCodes.MISSING_SERVLET_CONTEXT);
+        }
+        return servletContext;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean bind(Class<?> component, Set<Class<?>> providerContracts) {
+        boolean isBound = false;
+        if (isJaxRsClass(component)) {
+            registerBindingsInHK2(component, providerContracts);
+            isBound = true;
+        }
+        return isBound;
+    }
+
+    private void registerBindingsInHK2(Class<?> componentClass, Set<Class<?>> providerContracts) {
+        ServiceBindingBuilder componentBindingBuilder = getBindingBuilder(componentClass);
+        //noinspection unchecked
+        componentBindingBuilder.to(componentClass);
+        bindProviderContracts(componentBindingBuilder, providerContracts);
+
+        DynamicConfiguration dynamicConfiguration = Injections.getConfiguration(serviceLocator);
+        Injections.addBinding(componentBindingBuilder, dynamicConfiguration);
+        dynamicConfiguration.commit();
+    }
+
+    private ServiceBindingBuilder getBindingBuilder(Class<?> component) {
+        GuiceToHK2Factory guiceFactory = new GuiceToHK2Factory(component, injector, serviceLocator);
+        return Injections.newFactoryBinder(guiceFactory);
+    }
+
+    private void bindProviderContracts(ServiceBindingBuilder componentBindingBuilder, Set<Class<?>> providerContracts) {
+        if (providerContracts != null) {
+            for (Class<?> providerContract : providerContracts) {
+                //noinspection unchecked
+                componentBindingBuilder.to(providerContract);
+            }
+        }
+    }
+
+    private boolean isJaxRsClass(Class<?> component) {
+        return component.isAnnotationPresent(Path.class) || component.isAnnotationPresent(Provider.class);
+    }
+
+    @Override
+    public void done() {
+    }
+}

--- a/rest/jersey2/src/main/java/org/seedstack/seed/rest/jersey2/internal/GuiceToHK2Factory.java
+++ b/rest/jersey2/src/main/java/org/seedstack/seed/rest/jersey2/internal/GuiceToHK2Factory.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.jersey2.internal;
+
+import com.google.inject.Injector;
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.api.ServiceLocator;
+
+/**
+ * A generic HK2 factory backed by Guice.
+ *
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+class GuiceToHK2Factory implements Factory {
+
+    private final Class<?> componentClass;
+    private final Injector injector;
+    private final ServiceLocator serviceLocator;
+
+    public GuiceToHK2Factory(Class<?> componentClass, Injector injector, ServiceLocator locator) {
+        this.injector = injector;
+        this.componentClass = componentClass;
+        this.serviceLocator = locator;
+    }
+
+    @Override
+    public Object provide() {
+        Object instance = injector.getInstance(componentClass);
+        if (instance != null) {
+            serviceLocator.inject(instance);
+        }
+        return instance;
+    }
+
+    @Override
+    public void dispose(Object instance) {
+
+    }
+}

--- a/rest/jersey2/src/main/java/org/seedstack/seed/rest/jersey2/internal/GuiceToHK2Factory.java
+++ b/rest/jersey2/src/main/java/org/seedstack/seed/rest/jersey2/internal/GuiceToHK2Factory.java
@@ -39,6 +39,5 @@ class GuiceToHK2Factory implements Factory {
 
     @Override
     public void dispose(Object instance) {
-
     }
 }

--- a/rest/jersey2/src/main/java/org/seedstack/seed/rest/jersey2/internal/Jersey2ErrorCodes.java
+++ b/rest/jersey2/src/main/java/org/seedstack/seed/rest/jersey2/internal/Jersey2ErrorCodes.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.jersey2.internal;
+
+import org.seedstack.seed.ErrorCode;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+enum Jersey2ErrorCodes implements ErrorCode {
+    MISSING_INJECTOR,
+    MISSING_SERVLET_CONTEXT
+}

--- a/rest/jersey2/src/main/resources/META-INF/errors/org.seedstack.seed.rest.jersey2.internal.Jersey2ErrorCodes.properties
+++ b/rest/jersey2/src/main/resources/META-INF/errors/org.seedstack.seed.rest.jersey2.internal.Jersey2ErrorCodes.properties
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+MISSING_INJECTOR.message=The ServletContext doesn't contains the Guice Injector.
+MISSING_SERVLET_CONTEXT.message=Jersey was not able to provide the ServletContext.

--- a/rest/jersey2/src/main/resources/META-INF/services/org.glassfish.jersey.server.spi.ComponentProvider
+++ b/rest/jersey2/src/main/resources/META-INF/services/org.glassfish.jersey.server.spi.ComponentProvider
@@ -1,0 +1,1 @@
+org.seedstack.seed.rest.jersey2.internal.GuiceComponentProvider

--- a/rest/jersey2/src/test/java/org/seedstack/seed/rest/jersey2/internal/GuiceComponentProviderTest.java
+++ b/rest/jersey2/src/test/java/org/seedstack/seed/rest/jersey2/internal/GuiceComponentProviderTest.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.jersey2.internal;
+
+import com.google.common.collect.Sets;
+import com.google.inject.Injector;
+import com.sun.org.apache.xpath.internal.operations.String;
+import mockit.*;
+import mockit.integration.junit4.JMockit;
+import org.glassfish.hk2.api.DynamicConfiguration;
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.utilities.binding.BindingBuilder;
+import org.glassfish.hk2.utilities.binding.ServiceBindingBuilder;
+import org.glassfish.jersey.internal.inject.Injections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hk2.guice.bridge.api.GuiceBridge;
+import org.jvnet.hk2.guice.bridge.api.GuiceIntoHK2Bridge;
+import org.seedstack.seed.SeedException;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.Path;
+import javax.ws.rs.ext.Provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+@RunWith(JMockit.class)
+public class GuiceComponentProviderTest {
+
+    @Tested
+    private GuiceComponentProvider underTest;
+
+    @Mocked
+    private ServiceLocator serviceLocator;
+    @Mocked
+    private ServletContext servletContext;
+    @Mocked
+    private Injector injector;
+    @Mocked
+    private GuiceIntoHK2Bridge guiceIntoHK2Bridge;
+    @Mocked
+    private ServiceBindingBuilder bindingBuilder;
+    @Mocked
+    private DynamicConfiguration dynamicConfiguration;
+
+    @Test
+    public void testInitializeSaveTheServiceLocator() throws Exception {
+        givenServiceLocator();
+
+        underTest.initialize(serviceLocator);
+
+        ServiceLocator initializedServiceLocator = Deencapsulation.getField(underTest, ServiceLocator.class);
+        assertThat(initializedServiceLocator).isEqualTo(serviceLocator);
+    }
+
+    @Test
+    public void testGetTheInjector() throws Exception {
+        givenServiceLocator();
+
+        underTest.initialize(serviceLocator);
+
+        Injector initializedInjector = Deencapsulation.getField(underTest, Injector.class);
+        assertThat(initializedInjector).isEqualTo(injector);
+    }
+
+    private void givenServiceLocator() {
+        new NonStrictExpectations() {{
+            serviceLocator.getService(ServletContext.class); result = servletContext;
+            servletContext.getAttribute(Injector.class.getName()); result = injector;
+            serviceLocator.getService(GuiceIntoHK2Bridge.class); result = guiceIntoHK2Bridge;
+        }};
+    }
+
+    @Test
+    public void testMissingServletContext() throws Exception {
+        givenMissingServletContext();
+        try {
+            underTest.initialize(serviceLocator);
+            fail();
+        } catch (SeedException e) {
+            assertThat(e.getErrorCode()).isEqualTo(Jersey2ErrorCodes.MISSING_SERVLET_CONTEXT);
+            assertThat(e.getDescription()).isEqualTo("Jersey was not able to provide the ServletContext.");
+        }
+    }
+
+    private void givenMissingServletContext() {
+        new NonStrictExpectations() {{
+            serviceLocator.getService(ServletContext.class);
+            result = null;
+        }};
+    }
+
+    @Test
+    public void testMissingInjector() throws Exception {
+        givenServletContextAndMissingInjector();
+        try {
+            underTest.initialize(serviceLocator);
+            fail();
+        } catch (SeedException e) {
+            assertThat(e.getErrorCode()).isEqualTo(Jersey2ErrorCodes.MISSING_INJECTOR);
+            assertThat(e.getDescription()).isEqualTo("The ServletContext doesn't contains the Guice Injector.");
+        }
+    }
+
+    private void givenServletContextAndMissingInjector() {
+        new NonStrictExpectations() {{
+            serviceLocator.getService(ServletContext.class);
+            result = servletContext;
+            servletContext.getAttribute(Injector.class.getName());
+            result = null;
+        }};
+    }
+
+    @Test
+    public void testPrepareHK2Bridge(@Mocked final GuiceBridge guiceBridge) throws Exception {
+        givenServiceLocator();
+        new Expectations() {{
+            serviceLocator.getService(GuiceIntoHK2Bridge.class);
+            result = guiceIntoHK2Bridge;
+        }};
+
+        underTest.initialize(serviceLocator);
+
+        new Verifications() {{
+            guiceBridge.initializeGuiceBridge(serviceLocator);
+            serviceLocator.getService(GuiceIntoHK2Bridge.class);
+            guiceIntoHK2Bridge.bridgeGuiceInjector(injector);
+        }};
+    }
+
+    @Test
+    public void testDoNotBindNonResourceClasses() throws Exception {
+        boolean isBound = underTest.bind(String.class, null);
+        assertThat(isBound).isFalse();
+    }
+
+    @Test
+    public void testBindResourceClasses() throws Exception {
+        givenServiceLocator();
+        givenInjections();
+        underTest.initialize(serviceLocator);
+        @Path("/") class MyResource { }
+
+        boolean isBound = underTest.bind(MyResource.class, null);
+
+        assertThat(isBound).isTrue();
+    }
+
+    @Provider interface MyProvider { }
+    class MyProviderImpl implements MyProvider { }
+
+    @Test
+    public void testBind() throws Exception {
+        givenServiceLocator();
+        givenInjections();
+        underTest.initialize(serviceLocator);
+
+        underTest.bind(MyProvider.class, Sets.<Class<?>>newHashSet(MyProviderImpl.class));
+
+        new Verifications() {{
+           bindingBuilder.to(MyProvider.class);
+           bindingBuilder.to(MyProviderImpl.class);
+        }};
+    }
+
+    private void givenInjections() {
+        new MockUp<Injections>() {
+            @Mock
+            DynamicConfiguration getConfiguration(final ServiceLocator locator) {
+                return dynamicConfiguration;
+            }
+            @Mock
+            <T> ServiceBindingBuilder<T> newFactoryBinder(final Factory<T> factory) {
+                return bindingBuilder;
+            }
+            @Mock
+            void addBinding(final BindingBuilder<?> builder, final DynamicConfiguration configuration) {}
+        };
+    }
+}

--- a/rest/jersey2/src/test/java/org/seedstack/seed/rest/jersey2/internal/GuiceToHK2FactoryTest.java
+++ b/rest/jersey2/src/test/java/org/seedstack/seed/rest/jersey2/internal/GuiceToHK2FactoryTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.jersey2.internal;
+
+import com.google.inject.Injector;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.Verifications;
+import mockit.integration.junit4.JMockit;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+@RunWith(JMockit.class)
+public class GuiceToHK2FactoryTest {
+
+    final SomeClass someObject = new SomeClass();
+    private GuiceToHK2Factory underTest;
+    @Mocked
+    private Injector injector;
+    @Mocked
+    private ServiceLocator serviceLocator;
+
+    @Before
+    public void setUp() throws Exception {
+        underTest = new GuiceToHK2Factory(SomeClass.class, injector, serviceLocator);
+    }
+
+    @Test
+    public void testProvide() throws Exception {
+        new Expectations() {{
+            injector.getInstance(SomeClass.class);
+            result = someObject;
+        }};
+
+        Object providedObject = underTest.provide();
+
+        assertThat(providedObject).isEqualTo(someObject);
+        new Verifications() {{
+            serviceLocator.inject(someObject);
+        }};
+    }
+
+    @Test
+    public void testProvideNull() throws Exception {
+        new Expectations() {{
+            injector.getInstance(SomeClass.class); result = null;
+        }};
+
+        Object providedObject = underTest.provide();
+
+        assertThat(providedObject).isNull();
+    }
+
+    class SomeClass {
+    }
+}

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -23,5 +23,6 @@
         <module>specs</module>
         <module>core</module>
         <module>jersey1</module>
+        <module>jersey2</module>
     </modules>
 </project>


### PR DESCRIPTION
Add a JAX-RS `ComponentProvider` with an HK2/Guice bridge.

It only misses support in Arquillian and Undertow, so integration testing is not possible yet.