### PR TITLE
Fix @Ignore annotation

### DIFF
--- a/specs/pom.xml
+++ b/specs/pom.xml
@@ -60,5 +60,11 @@
             <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.nuun</groupId>
+            <artifactId>kernel-core</artifactId>
+            <version>${nuun-kernel.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/specs/src/it/java/org/seedstack/seed/IgnoreIT.java
+++ b/specs/src/it/java/org/seedstack/seed/IgnoreIT.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed;
+
+import com.google.inject.ConfigurationException;
+import com.google.inject.Injector;
+import io.nuun.kernel.api.Kernel;
+import io.nuun.kernel.core.internal.KernelCoreFactory;
+import io.nuun.kernel.core.internal.ModuleEmbedded;
+import org.assertj.core.api.Assertions;
+import org.junit.*;
+
+import static io.nuun.kernel.core.NuunCore.createKernel;
+import static io.nuun.kernel.core.NuunCore.newKernelConfiguration;
+
+/**
+ * @author Pierre THIROUIN (pierre.thirouin@ext.inetpsa.com)
+ */
+public class IgnoreIT {
+
+    private static Kernel kernel;
+    private static Injector injector;
+
+    @org.seedstack.seed.Ignore
+    @Scan
+    static class IgnoredClass {
+    }
+
+    @Scan
+    static class ScannedClass {
+    }
+
+    @interface Scan {}
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        kernel = createKernel(newKernelConfiguration().withoutSpiPluginsLoader().addPlugin(IgnorePlugin.class));
+        kernel.init();
+        kernel.start();
+        injector = kernel.objectGraph().as(Injector.class);
+    }
+
+    @Test
+    public void testScanWorks() throws Exception {
+        ScannedClass instance = injector.getInstance(ScannedClass.class);
+        Assertions.assertThat(instance).isNotNull();
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void testIgnoreFeature() throws Exception {
+        injector.getInstance(IgnoredClass.class);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        kernel.stop();
+    }
+}

--- a/specs/src/it/java/org/seedstack/seed/IgnorePlugin.java
+++ b/specs/src/it/java/org/seedstack/seed/IgnorePlugin.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed;
+
+
+import io.nuun.kernel.api.plugin.InitState;
+import io.nuun.kernel.api.plugin.context.InitContext;
+import io.nuun.kernel.api.plugin.request.BindingRequest;
+import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
+import io.nuun.kernel.core.AbstractPlugin;
+import org.kametic.specifications.Specification;
+
+import java.util.Collection;
+
+/**
+ * @author Pierre THIROUIN (pierre.thirouin@ext.inetpsa.com)
+ */
+public class IgnorePlugin extends AbstractPlugin {
+
+    @Override
+    public String name() {
+        return "ignore-plugin";
+    }
+
+    @Override
+    public Collection<BindingRequest> bindingRequests() {
+        return bindingRequestsBuilder().annotationType(IgnoreIT.Scan.class).build();
+    }
+}

--- a/specs/src/main/java/org/seedstack/seed/Ignore.java
+++ b/specs/src/main/java/org/seedstack/seed/Ignore.java
@@ -19,6 +19,7 @@ import java.lang.annotation.Target;
  *
  * @author adrien.lauer@mpsa.com
  */
+@io.nuun.kernel.api.annotations.Ignore
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.FIELD, ElementType.METHOD, ElementType.PACKAGE, ElementType.LOCAL_VARIABLE })


### PR DESCRIPTION
The Seed `@Ignore` annotation was not annotated by the Nuun one.

In the previous version of Nuun the ignore policy was based on a regex. But now only the annotations meta annotated by the Nuun `@Ignore` are used by the ignore policy. 

This PR fix the Seed annotation and add a test for this.