### PR TITLE
Add a RestProvider facet

### DIFF
--- a/rest/core/src/main/java/org/seedstack/seed/rest/internal/RestPlugin.java
+++ b/rest/core/src/main/java/org/seedstack/seed/rest/internal/RestPlugin.java
@@ -24,6 +24,7 @@ import org.seedstack.seed.rest.internal.hal.RelRegistryImpl;
 import org.seedstack.seed.rest.internal.jsonhome.JsonHome;
 import org.seedstack.seed.rest.internal.jsonhome.JsonHomeRootResource;
 import org.seedstack.seed.rest.internal.jsonhome.Resource;
+import org.seedstack.seed.rest.spi.RestProvider;
 import org.seedstack.seed.rest.spi.RootResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,15 +32,12 @@ import org.slf4j.LoggerFactory;
 import javax.servlet.ServletContext;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Variant;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
  */
-public class RestPlugin extends AbstractPlugin {
+public class RestPlugin extends AbstractPlugin implements RestProvider {
     public static final Specification<Class<?>> resourcesSpecification = new JaxRsResourceSpecification();
     public static final Specification<Class<?>> providersSpecification = new JaxRsProviderSpecification();
     private static final Logger LOGGER = LoggerFactory.getLogger(RestPlugin.class);
@@ -153,11 +151,13 @@ public class RestPlugin extends AbstractPlugin {
         return enabled;
     }
 
-    public Collection<Class<?>> getResources() {
-        return Collections.unmodifiableCollection(resources);
+    @Override
+    public Set<Class<?>> resources() {
+        return new HashSet<Class<?>>(resources);
     }
 
-    public Collection<Class<?>> getProviders() {
-        return Collections.unmodifiableCollection(providers);
+    @Override
+    public Set<Class<?>> providers() {
+        return new HashSet<Class<?>>(providers);
     }
 }

--- a/rest/jersey2/src/main/java/org/seedstack/seed/rest/jersey2/internal/Jersey2Plugin.java
+++ b/rest/jersey2/src/main/java/org/seedstack/seed/rest/jersey2/internal/Jersey2Plugin.java
@@ -12,9 +12,13 @@ import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.core.AbstractPlugin;
 import org.seedstack.seed.rest.internal.RestPlugin;
+import org.seedstack.seed.rest.spi.RestProvider;
 import org.seedstack.seed.web.internal.WebPlugin;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class Jersey2Plugin extends AbstractPlugin {
     @Override
@@ -30,19 +34,26 @@ public class Jersey2Plugin extends AbstractPlugin {
 
     @Override
     public Collection<Class<?>> requiredPlugins() {
-        return Lists.<Class<?>>newArrayList(WebPlugin.class, RestPlugin.class);
+        return Lists.<Class<?>>newArrayList(WebPlugin.class, RestPlugin.class, RestProvider.class);
     }
 
     @Override
     public InitState init(InitContext initContext) {
         RestPlugin restPlugin = initContext.dependency(RestPlugin.class);
+        List<RestProvider> restProviders = initContext.dependencies(RestProvider.class);
+        Set<Class<?>> resources = new HashSet<Class<?>>();
+        Set<Class<?>> providers = new HashSet<Class<?>>();
+        for (RestProvider restProvider : restProviders) {
+            resources.addAll(restProvider.resources());
+            providers.addAll(restProvider.providers());
+        }
 
         if (restPlugin.isEnabled()) {
             initContext.dependency(WebPlugin.class).registerAdditionalModule(
                     new Jersey2Module(
                             restPlugin.getConfiguration(),
-                            restPlugin.getResources(),
-                            restPlugin.getProviders()
+                            resources,
+                            providers
                     )
             );
         }

--- a/rest/specs/pom.xml
+++ b/rest/specs/pom.xml
@@ -20,6 +20,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.seedstack.seed</groupId>
+            <artifactId>seed-specs</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>

--- a/rest/specs/src/main/java/org/seedstack/seed/rest/spi/RestProvider.java
+++ b/rest/specs/src/main/java/org/seedstack/seed/rest/spi/RestProvider.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2013-2016, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest.spi;
+
+import io.nuun.kernel.api.annotations.Facet;
+
+import java.util.Set;
+
+@Facet
+public interface RestProvider {
+
+    Set<Class<?>> resources();
+
+    Set<Class<?>> providers();
+}


### PR DESCRIPTION
The facet provider JAX-RS resources and providers. It is implemented by RestPlugin and required by the Jersey2Plugin. It allow to others plugins to provide JAX-RS classes, e.g. the SwaggerPlugin