### PR TITLE
Bind Hypermedia classes outside of Servlet context

### DIFF
--- a/rest/core/src/it/java/org/seedstack/seed/rest/HypermediaIT.java
+++ b/rest/core/src/it/java/org/seedstack/seed/rest/HypermediaIT.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2013-2016, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.seed.rest;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.seedstack.seed.it.SeedITRunner;
+
+import javax.inject.Inject;
+
+@RunWith(SeedITRunner.class)
+public class HypermediaIT {
+
+    @Inject
+    private RelRegistry relRegistry;
+
+    @Test
+    public void relRegistryIsInjectable() {
+        Assertions.assertThat(relRegistry).isNotNull();
+    }
+}

--- a/rest/core/src/main/java/org/seedstack/seed/rest/internal/RestPlugin.java
+++ b/rest/core/src/main/java/org/seedstack/seed/rest/internal/RestPlugin.java
@@ -78,11 +78,6 @@ public class RestPlugin extends AbstractPlugin implements RestProvider {
 
     @Override
     public InitState init(InitContext initContext) {
-        if (servletContext == null) {
-            enabled = false;
-            LOGGER.info("No servlet context detected, REST support disabled");
-            return InitState.INITIALIZED;
-        }
 
         restConfiguration.init(initContext.dependency(ConfigurationProvider.class).getConfiguration());
 
@@ -90,9 +85,15 @@ public class RestPlugin extends AbstractPlugin implements RestProvider {
         resources = scannedClasses.get(RestPlugin.resourcesSpecification);
         providers = scannedClasses.get(RestPlugin.providersSpecification);
 
-        configureExceptionMappers();
-
         initializeHypermedia();
+
+        if (servletContext == null) {
+            enabled = false;
+            LOGGER.info("No servlet context detected, REST support disabled");
+            return InitState.INITIALIZED;
+        }
+
+        configureExceptionMappers();
 
         if (restConfiguration.isJsonHomeEnabled()) {
             addRootResourceVariant(new Variant(new MediaType("application", "json"), null, null), JsonHomeRootResource.class);
@@ -123,20 +124,16 @@ public class RestPlugin extends AbstractPlugin implements RestProvider {
 
     @Override
     public Object nativeUnitModule() {
-        if (enabled) {
             return new AbstractModule() {
                 @Override
                 protected void configure() {
                     install(new RestModule(restConfiguration, resources, providers));
                     install(new HypermediaModule(jsonHome, relRegistry));
-                    if (!rootResourcesByVariant.isEmpty()) {
+                    if (enabled && !rootResourcesByVariant.isEmpty()) {
                         install(new RootResourcesModule(rootResourcesByVariant));
                     }
                 }
             };
-        }
-
-        return null;
     }
 
     public void addRootResourceVariant(Variant variant, Class<? extends RootResource> rootResource) {

--- a/rest/core/src/test/java/org/seedstack/seed/rest/internal/RestPluginTest.java
+++ b/rest/core/src/test/java/org/seedstack/seed/rest/internal/RestPluginTest.java
@@ -75,6 +75,11 @@ public class RestPluginTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testWithoutServletContext() throws Exception {
+        givenConfiguration();
+        givenSpecifications(
+                new Pair(resourcesSpecification, MyResource.class),
+                new Pair(providersSpecification, MyProvider.class)
+        );
         InitState init = underTest.init(initContext);
         assertThat(init).isEqualTo(InitState.INITIALIZED);
     }

--- a/web/websocket/src/it/java/org/seedstack/seed/web/WebSocketIT.java
+++ b/web/websocket/src/it/java/org/seedstack/seed/web/WebSocketIT.java
@@ -60,7 +60,7 @@ public class WebSocketIT extends AbstractSeedWebIT {
         final Session session2 = connectToServer(baseUrl, chatClientEndpoint2);
         assertNotNull(session2);
 
-        assertTrue(ChatClientEndpoint1.latch.await(2, TimeUnit.SECONDS));
+        assertTrue(ChatClientEndpoint1.latch.await(2, TimeUnit.SECONDS)); // FIXME there are concurrency issues here
         assertTrue(ChatClientEndpoint2.latch.await(2, TimeUnit.SECONDS));
         assertEquals("echo: " + ChatClientEndpoint2.TEXT, ChatClientEndpoint1.response);
         assertEquals("echo: " + ChatClientEndpoint2.TEXT, ChatClientEndpoint2.response);


### PR DESCRIPTION
The `RelRegistry` has to be always bound as it can be injected in class that are not resources.
Currently if the class is injected in an `Assembler`, it will throw a Guice exception when a (non web) integration test is run.

The PR has been tested on the microservice sample.