### PR TITLE
Exclude Guice 3 from HK2 guice-bridge

### DIFF
--- a/rest/jersey2/pom.xml
+++ b/rest/jersey2/pom.xml
@@ -55,6 +55,12 @@
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>guice-bridge</artifactId>
             <version>2.4.0-b34</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.inject</groupId>
+                    <artifactId>guice</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
Guice 3 were conflicting with sisu-guice.