### PR TITLE
Bind resources only in servlet context

### DIFF
--- a/rest/core/src/main/java/org/seedstack/seed/rest/internal/RestPlugin.java
+++ b/rest/core/src/main/java/org/seedstack/seed/rest/internal/RestPlugin.java
@@ -131,10 +131,12 @@ public class RestPlugin extends AbstractPlugin implements RestProvider {
             return new AbstractModule() {
                 @Override
                 protected void configure() {
-                    install(new RestModule(restConfiguration, resources, providers));
                     install(new HypermediaModule(jsonHome, relRegistry));
-                    if (enabled && !rootResourcesByVariant.isEmpty()) {
-                        install(new RootResourcesModule(rootResourcesByVariant));
+                    if (enabled) {
+                        install(new RestModule(restConfiguration, resources, providers));
+                        if (!rootResourcesByVariant.isEmpty()) {
+                            install(new RootResourcesModule(rootResourcesByVariant));
+                        }
                     }
                 }
             };


### PR DESCRIPTION
Hypermedia classes are always bound but not the resources. They aren't bound outside of Servlet context.