### PR TITLE
Improve web scanning, fixes #229

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [fix] Fix StackOverflowError under Tomcat in Eclipse WTP when auto-configuring Logback.
 * [chg] Default diagnostic dump changed from JSON to YAML.
 * [chg] Using the application classloader to load properties for additional JNDI contexts (paths should not start with `/` anymore).
+* [fix] Fix resolution of `WEB-INF/classes` under Tomcat 8 when using resource overlay (PreResources, PostResources).
 
 # Version 3.1.0 (2017-02-16)
 

--- a/core/src/it/java/org/seedstack/seed/core/ConfigurationIT.java
+++ b/core/src/it/java/org/seedstack/seed/core/ConfigurationIT.java
@@ -139,7 +139,7 @@ public class ConfigurationIT {
     @Test
     public void properties_files_are_accessible_in_configuration() {
         Holder holder = injector.getInstance(Holder.class);
-        assertThat(holder.application.getConfiguration().get(String.class, "test\\.keyFromProperties")).isEqualTo("testValue");
+        assertThat(holder.application.getConfiguration().get(String.class, "test.keyFromProperties")).isEqualTo("testValue");
     }
 
     @Test

--- a/core/src/main/java/org/seedstack/seed/core/SeedRuntime.java
+++ b/core/src/main/java/org/seedstack/seed/core/SeedRuntime.java
@@ -100,7 +100,7 @@ public class SeedRuntime {
 
                 if (pluginPackage != null && pluginPackage.getName().startsWith(SEED_PACKAGE_PREFIX)) {
                     String pluginVersion = pluginPackage.getImplementationVersion();
-                    if (pluginVersion != null && !pluginVersion.equals(seedVersion)) {
+                    if (!seedVersion.equals(pluginVersion)) {
                         inconsistentPlugins.add(plugin.name());
                     }
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <aopalliance.version>1.0</aopalliance.version>
         <glassfish-javax.el.version>3.0.0</glassfish-javax.el.version>
 
-        <compatibility.skip>true</compatibility.skip>
+        <compatibility.version>3.1.0</compatibility.version>
 
         <bintray.package>seed</bintray.package>
     </properties>

--- a/web/core/src/it/java/org/seedstack/seed/web/WebDiagnosticsIT.java
+++ b/web/core/src/it/java/org/seedstack/seed/web/WebDiagnosticsIT.java
@@ -14,7 +14,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.seedstack.seed.diagnostic.DiagnosticManager;
 import org.seedstack.seed.it.AbstractSeedWebIT;
-import org.seedstack.seed.web.internal.WebPlugin;
 
 import javax.inject.Inject;
 import java.util.Map;
@@ -23,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class WebDiagnosticsIT extends AbstractSeedWebIT {
     @Inject
-    DiagnosticManager diagnosticManager;
+    private DiagnosticManager diagnosticManager;
 
     @Deployment
     public static WebArchive createDeployment() {
@@ -37,7 +36,7 @@ public class WebDiagnosticsIT extends AbstractSeedWebIT {
         Map<String, Object> diagnosticInfo = diagnosticManager.getDiagnosticInfo(null);
 
         assertThat(diagnosticInfo).isNotNull();
-        Map<String, Object> webInfo = (Map<String, Object>) diagnosticInfo.get(WebPlugin.WEB_PLUGIN_PREFIX);
+        Map<String, Object> webInfo = (Map<String, Object>) diagnosticInfo.get("web");
 
         assertThat(webInfo).isNotEmpty();
     }

--- a/web/core/src/it/resources/application.yaml
+++ b/web/core/src/it/resources/application.yaml
@@ -6,5 +6,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-web:
-  static: false
+logging:
+  level: WARN

--- a/web/core/src/it/resources/configuration/all-disabled.yaml
+++ b/web/core/src/it/resources/configuration/all-disabled.yaml
@@ -6,7 +6,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-logging: WARN
 web:
   static:
     minification: false

--- a/web/core/src/it/resources/configuration/cors.yaml
+++ b/web/core/src/it/resources/configuration/cors.yaml
@@ -6,7 +6,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-logging: WARN
 web:
   cors:
     enabled: true

--- a/web/core/src/it/resources/configuration/gzip-disabled.yaml
+++ b/web/core/src/it/resources/configuration/gzip-disabled.yaml
@@ -6,7 +6,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-logging: WARN
 web:
   static:
     gzip: false;

--- a/web/core/src/it/resources/configuration/gzip-otf-disabled.yaml
+++ b/web/core/src/it/resources/configuration/gzip-otf-disabled.yaml
@@ -6,7 +6,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-logging: WARN
 web:
   static:
     gzipOnTheFly: false;

--- a/web/core/src/it/resources/configuration/minified-disabled.yaml
+++ b/web/core/src/it/resources/configuration/minified-disabled.yaml
@@ -6,7 +6,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-logging: WARN
 web:
   static:
     minification: false

--- a/web/core/src/main/java/org/seedstack/seed/web/internal/WebErrorCode.java
+++ b/web/core/src/main/java/org/seedstack/seed/web/internal/WebErrorCode.java
@@ -13,6 +13,7 @@ import org.seedstack.shed.exception.ErrorCode;
  * Enumerates all Web error codes.
  */
 public enum WebErrorCode implements ErrorCode {
+    CANNOT_RESOLVE_WEB_RESOURCE_LOCATION,
     ERROR_RETRIEVING_RESOURCE,
     UNABLE_TO_DETERMINE_RESOURCE_INFO,
     UNABLE_TO_SCAN_TOMCAT_JNDI_DIRECTORY,

--- a/web/core/src/main/java/org/seedstack/seed/web/internal/diagnostic/WebDiagnosticPlugin.java
+++ b/web/core/src/main/java/org/seedstack/seed/web/internal/diagnostic/WebDiagnosticPlugin.java
@@ -10,9 +10,9 @@ package org.seedstack.seed.web.internal.diagnostic;
 import com.google.common.collect.Lists;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
-import org.seedstack.seed.diagnostic.DiagnosticManager;
 import org.seedstack.seed.core.SeedRuntime;
 import org.seedstack.seed.core.internal.AbstractSeedPlugin;
+import org.seedstack.seed.diagnostic.DiagnosticManager;
 import org.seedstack.seed.web.WebConfig;
 import org.seedstack.seed.web.spi.FilterDefinition;
 import org.seedstack.seed.web.spi.ListenerDefinition;
@@ -24,8 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletContext;
 import java.util.List;
-
-import static org.seedstack.seed.web.internal.WebPlugin.WEB_PLUGIN_PREFIX;
 
 public class WebDiagnosticPlugin extends AbstractSeedPlugin implements WebProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(WebDiagnosticPlugin.class);
@@ -50,7 +48,7 @@ public class WebDiagnosticPlugin extends AbstractSeedPlugin implements WebProvid
 
         if (servletContext != null) {
             diagnosticManager.registerDiagnosticInfoCollector(
-                    WEB_PLUGIN_PREFIX,
+                    "web",
                     new WebDiagnosticCollector(servletContext)
             );
         }

--- a/web/core/src/main/resources/org/seedstack/seed/web/internal/WebErrorCode.properties
+++ b/web/core/src/main/resources/org/seedstack/seed/web/internal/WebErrorCode.properties
@@ -6,6 +6,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
+CANNOT_RESOLVE_WEB_RESOURCE_LOCATION=Cannot resolve Web resource location '${path}'.
 ERROR_RETRIEVING_RESOURCE=An error occurred during static resource resolution.
 UNABLE_TO_DETERMINE_RESOURCE_INFO=Unable to determine information of static resource '${path}'.
 UNABLE_TO_SCAN_TOMCAT_JNDI_DIRECTORY=Unable to scan Tomcat JNDI directory '${url}'.


### PR DESCRIPTION
This enables to find multiple locations for `WEB-INF/classes`, fixing scanning limitations under Tomcat 8 when using resource "overlays" (PreResources/PostResources).