### PR TITLE
Prevents stack from setting up an enviroment when a test is ignored.

### DIFF
--- a/testing/junit4/src/main/java/org/seedstack/seed/testing/junit4/internal/JUnit4Runner.java
+++ b/testing/junit4/src/main/java/org/seedstack/seed/testing/junit4/internal/JUnit4Runner.java
@@ -107,7 +107,7 @@ public class JUnit4Runner extends BlockJUnit4ClassRunner {
                 .map(this::instantiate)
                 .collect(Collectors.toList());
         try {
-            if (launchMode == LaunchMode.PER_TEST) {
+            if (launchMode == LaunchMode.PER_TEST && !isIgnored(method)) {
                 doStart();
             }
 

--- a/testing/junit4/src/test/java/org/seedstack/seed/testing/junit4/PerTestExpectedIT.java
+++ b/testing/junit4/src/test/java/org/seedstack/seed/testing/junit4/PerTestExpectedIT.java
@@ -9,9 +9,14 @@
 package org.seedstack.seed.testing.junit4;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 import com.google.inject.CreationException;
 import javax.inject.Inject;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.seedstack.seed.testing.Expected;
@@ -25,9 +30,27 @@ public class PerTestExpectedIT {
     @Inject
     private Object object;
 
+    @BeforeClass
+    public static void classSetup() {
+        TestITLauncher.resetLaunchCount();
+    }
+
     @Test
     @Expected(CreationException.class)
     public void injectionShouldNotWork() {
         assertThat(object).isNull();
     }
+
+    @Test
+    @Ignore
+    public void testThatIgnoredTestAreNotInitialized() throws Exception {
+        fail();
+    }
+
+    @AfterClass
+    public static void afterClassTest() throws Exception {
+        assertThat(TestITLauncher.getLaunchCount()).isEqualTo(1);
+
+    }
+
 }

--- a/testing/junit4/src/test/java/org/seedstack/seed/testing/junit4/fixtures/TestITLauncher.java
+++ b/testing/junit4/src/test/java/org/seedstack/seed/testing/junit4/fixtures/TestITLauncher.java
@@ -25,8 +25,11 @@ import org.seedstack.seed.spi.SeedLauncher;
 public class TestITLauncher implements SeedLauncher {
     private Kernel kernel;
 
+    private static int launchCount = 0;
+
     @Override
     public void launch(String[] args, Map<String, String> kernelParameters) {
+        launchCount += 1;
         KernelConfiguration kernelConfiguration = NuunCore.newKernelConfiguration();
         for (Map.Entry<String, String> kernelParameter : kernelParameters.entrySet()) {
             kernelConfiguration.param(kernelParameter.getKey(), kernelParameter.getValue());
@@ -68,6 +71,14 @@ public class TestITLauncher implements SeedLauncher {
     @Override
     public Optional<Kernel> getKernel() {
         return Optional.ofNullable(kernel);
+    }
+
+    public static void resetLaunchCount() {
+        launchCount = 0;
+    }
+
+    public static int getLaunchCount() {
+        return launchCount;
     }
 
     @Override


### PR DESCRIPTION
Added a check that tells the it runner to not initialize in case of a ignored test, saving up IT- test Time and allows to disable profile-specific test without causing a failure (JPA test with test-environment connection, as an example)
Closes Issue #244

