### PR TITLE
Set AbstractTransactionManager to protected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 3.9.2 (????)
+ 
+ * [chg] `AbstractTransactionManager` is now scoped as package.
+
 # Version 3.9.1 (2019-11-30)
 
 * [new] Support for programmatic login through `SecuritySupport` interface (no need for Shiro-specific code anymore).

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-cli</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-core</artifactId>

--- a/core/src/main/java/org/seedstack/seed/core/internal/transaction/AbstractTransactionManager.java
+++ b/core/src/main/java/org/seedstack/seed/core/internal/transaction/AbstractTransactionManager.java
@@ -32,7 +32,7 @@ import org.seedstack.seed.transaction.spi.TransactionMetadataResolver;
 /**
  * Base class for common transaction manager behavior.
  */
-public abstract class AbstractTransactionManager implements TransactionManager {
+abstract class AbstractTransactionManager implements TransactionManager {
     private final MethodInterceptorImplementation methodInterceptorImplementation = new
             MethodInterceptorImplementation();
     @Inject

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.seedstack.seed</groupId>
     <artifactId>seed</artifactId>
-    <version>3.9.1-SNAPSHOT</version>
+    <version>3.9.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/rest/core/pom.xml
+++ b/rest/core/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed-rest</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-rest-core</artifactId>

--- a/rest/jersey2/pom.xml
+++ b/rest/jersey2/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed-rest</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-rest-jersey2</artifactId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-rest</artifactId>

--- a/rest/specs/pom.xml
+++ b/rest/specs/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed-rest</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-rest-specs</artifactId>

--- a/security/core/pom.xml
+++ b/security/core/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed-security</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-security-core</artifactId>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-security</artifactId>

--- a/security/specs/pom.xml
+++ b/security/specs/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.seedstack.seed</groupId>
 		<artifactId>seed-security</artifactId>
-		<version>3.9.1-SNAPSHOT</version>
+		<version>3.9.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>seed-security-specs</artifactId>

--- a/specs/pom.xml
+++ b/specs/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-specs</artifactId>

--- a/testing/arquillian/pom.xml
+++ b/testing/arquillian/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed-testing</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-testing-arquillian</artifactId>

--- a/testing/core/pom.xml
+++ b/testing/core/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed-testing</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-testing-core</artifactId>

--- a/testing/junit4/pom.xml
+++ b/testing/junit4/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed-testing</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-testing-junit4</artifactId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-testing</artifactId>

--- a/testing/specs/pom.xml
+++ b/testing/specs/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed-testing</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-testing-specs</artifactId>

--- a/web/core/pom.xml
+++ b/web/core/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed-web</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-web-core</artifactId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-web</artifactId>

--- a/web/security/pom.xml
+++ b/web/security/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed-web</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-web-security</artifactId>

--- a/web/specs/pom.xml
+++ b/web/specs/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed-web</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-web-specs</artifactId>

--- a/web/undertow/pom.xml
+++ b/web/undertow/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.seed</groupId>
         <artifactId>seed-web</artifactId>
-        <version>3.9.1-SNAPSHOT</version>
+        <version>3.9.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>seed-web-undertow</artifactId>


### PR DESCRIPTION
AbstractTransactionManager can be used as a base to implement TransactionManagers.

But, at the moment, there's a requirement to receive a ´TransactionLogger´, that is scoped as package in transaction internals.

Making it public, enables the possibility to use it as a base for a Transaction Manager 

Also updates the version to 3.9.2, as 3.9.1 was already released