### PR TITLE
Fix build with Maven 3.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
             </snapshots>
             <id>bintray-jfrog-jfrog-jars</id>
             <name>bintray-plugins</name>
-            <url>http://dl.bintray.com/jfrog/jfrog-jars</url>
+            <url>https://dl.bintray.com/jfrog/jfrog-jars</url>
         </pluginRepository>
     </pluginRepositories>
 
@@ -278,7 +278,7 @@
                     </releases>
                     <id>bintray</id>
                     <name>bintray</name>
-                    <url>http://dl.bintray.com/seedstack/jars</url>
+                    <url>https://dl.bintray.com/seedstack/jars</url>
                 </repository>
             </repositories>
         </profile>


### PR DESCRIPTION
Use HTTPS for bintray.com repository URL in order to avoid the repository to be blocked by Maven (see https://maven.apache.org/docs/3.8.1/release-notes.html#how-to-fix-when-i-get-a-http-repository-blocked).