### PR TITLE
Use HTTPS URL for Sonatype repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
     <repositories>
         <repository>
             <id>oss.sonatype.org-snapshot</id>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
Starting with Maven 3.8.1, repository with HTTP URLs are blocked by default (cf https://maven.apache.org/docs/3.8.1/release-notes.html#how-to-fix-when-i-get-a-http-repository-blocked).
Updating Sonatype repository URL to HTTPS allow a successful build with Maven 3.8.1 without any modification to Maven default configuration.